### PR TITLE
Fix test suite crash on Windows

### DIFF
--- a/perceval/algorithm/decomposition.py
+++ b/perceval/algorithm/decomposition.py
@@ -24,6 +24,7 @@ import copy
 
 import numpy as np
 import sympy as sp
+import scipy as scp
 
 from perceval.utils import Matrix, global_params
 
@@ -98,7 +99,7 @@ def decompose_triangle(u,
                             break
             if not solve_cell:
                 equation = cU_inv[0, 0] * u[n, j] + cU_inv[0, 1] * u[n + 1, j]
-                f = sp.lambdify([params_symbols], [equation])
+                f = sp.lambdify([params_symbols], [equation], modules=[np, scp])
                 g = lambda *p: np.real(np.abs(f(*p)))
                 x0 = [p.random() for p in params]
                 # look for a constraint solution first

--- a/perceval/components/circuit.py
+++ b/perceval/components/circuit.py
@@ -354,7 +354,7 @@ class ACircuit(ABC):
                     equation += abs(cU[i, j]-UP[i, j])
         equation = abs(equation)
 
-        f = sp.lambdify([params], equation, "numpy")
+        f = sp.lambdify([params], equation, modules=np)
         counter = 0
         while counter < max_try:
             x0 = [random.random()] * len(params)
@@ -451,7 +451,7 @@ class ACircuit(ABC):
             x0.append(p.random())
         cu = pattern.compute_unitary(use_symbolic=True)
 
-        f = sp.lambdify([params_symbols], cu - u)
+        f = sp.lambdify([params_symbols], cu - u, modules=np)
 
         def g(*params):
             return np.linalg.norm(np.array(f(*params)))

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     ],
     packages=['perceval', 'perceval.components', 'perceval.backends', 'perceval.utils', 'perceval.utils.renderer',
               'perceval.lib.phys', 'perceval.lib.symb', 'perceval.algorithm'],
-    install_requires=['sympy', 'numpy', 'scipy', 'tabulate', 'matplotlib', 'quandelibc>=0.5.1', 'drawSvg' ],
+    install_requires=['sympy', 'numpy', 'scipy', 'tabulate', 'matplotlib', 'quandelibc>=0.5.1', 'drawSvg', 'pycairo'],
     setup_requires=["scmver"],
     extras_require={"test": ["pytest", "pytest-cov"]},
     python_requires=">=3.6",


### PR DESCRIPTION
Inject pre-imported modules in lambdify calls to avoid sympy forced imports