### PR TITLE
reference bibtex perceval + typo in Shor

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,15 +41,19 @@ If you are using Perceval for academic work, please cite the `Perceval white pap
 
 .. code:: latex
 
-    @article{heurtel_perceval_2022,
-    title = {Perceval: {A} {Software} {Platform} for {Discrete} {Variable} {Photonic} {Quantum} {Computing}},
-    author = {Heurtel, Nicolas and Fyrillas, Andreas and de Gliniasty, Grégoire and Bihan, Raphaël Le and Malherbe, Sébastien and Pailhas, Marceau and Bourdoncle, Boris and Emeriau, Pierre-Emmanuel and Mezher, Rawad and Music, Luka and Belabas, Nadia and Valiron, Benoît and Senellart, Pascale and Mansfield, Shane and Senellart, Jean},
-    doi = {10.48550/ARXIV.2204.00602},
-    url = {https://arxiv.org/abs/2204.00602},
-    keywords = {Quantum Physics (quant-ph), Computational Physics (physics.comp-ph), FOS: Physical sciences, FOS: Physical sciences},
-    publisher = {arXiv},
-    year = {2022}
-    }
+    @article{heurtel2023perceval,
+    doi = {10.22331/q-2023-02-21-931},
+    url = {https://doi.org/10.22331/q-2023-02-21-931},
+    title = {Perceval: {A} {S}oftware {P}latform for {D}iscrete {V}ariable {P}hotonic {Q}uantum {C}omputing},
+    author = {Heurtel, Nicolas and Fyrillas, Andreas and Gliniasty, Gr{\'{e}}goire de and Le Bihan, Rapha{\"{e}}l and Malherbe, S{\'{e}}bastien and Pailhas, Marceau and Bertasi, Eric and Bourdoncle, Boris and Emeriau, Pierre-Emmanuel and Mezher, Rawad and Music, Luka and Belabas, Nadia and Valiron, Benoît and Senellart, Pascale and Mansfield, Shane and Senellart, Jean},
+    journal = {{Quantum}},
+    issn = {2521-327X},
+    publisher = {{Verein zur F{\"{o}}rderung des Open Access Publizierens in den Quantenwissenschaften}},
+    volume = {7},
+    pages = {931},
+    month = feb,
+    year = {2023}
+   }
 
 
 .. toctree::

--- a/docs/source/notebooks/Shor Implementation.ipynb
+++ b/docs/source/notebooks/Shor Implementation.ipynb
@@ -715,7 +715,7 @@
     "### Interpretation of the outcomes\n",
     "\n",
     "For each outcome we consider the values of qubits $x_2, x_1, x_0$ (where $x_0$ is 0) which represent a binary number between 0 and 7, here corresponding to 0, 4, 2 and 6 in the order of the table above.\n",
-    "After sampling the circuit, obtainig outcomes 2 or 6 allows to successfully compute the order $r=4$.\n",
+    "After sampling the circuit, obtaining outcomes 2 or 6 allows to successfully compute the order $r=4$.\n",
     "Obtaining outcome 0 is an expected failure of the quantum circuit, inherent to Shor's algorithm.\n",
     "Outcome 4 is an expected failure as well, as it only allows to compute the trivial factors 1 and 15.\n",
     "\n",


### PR DESCRIPTION
Change the bibtex reference of Perceval (now that perceval has been published in Quantum) 

+ small typo   ig -> ing