### PR TITLE
drawsvg<2.0 is a now a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ scipy
 tqdm
 Deprecated
 requests
-drawSvg
+drawSvg<2.0
 protobuf>=4.21.2

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
     ],
     packages=package_list,
     install_requires=['sympy', 'numpy', 'scipy', 'tabulate', 'matplotlib', 'quandelibc~=0.6.0', 'multipledispatch',
-                      'protobuf>=4.21.2', 'drawSvg', 'Deprecated', 'requests'],
+                      'protobuf>=4.21.2', 'drawSvg<2.0', 'Deprecated', 'requests'],
     setup_requires=["scmver"],
     extras_require={"test": ["pytest", "pytest-cov", "pytest-benchmark"]},
     python_requires=">=3.7",


### PR DESCRIPTION
Hi,

In https://pypi.org/project/drawsvg/#description  under section "Upgrading from version 1.x"

The doc authors mention few changes regarding capital "S". It seems Quandela was written for drawSvg 1.x and now when I try to import Perceval it fails as the version is not specified in your req. and therefore pip automatically installs the latest version.

I can think of Two solutions:
1- Adapt all code using DrawSvg to the new version [proper solution imho].
2- Force the installed version to the best know version that you have tested (1.9 seems to work fine for me)[quick workaround].

This PR implement the quick n dirty workaround, I didn't dare to go for the 1st option as I am new to Perceval 😅...

Best