### PR TITLE
Add Latex Renderer

### DIFF
--- a/perceval/rendering/canvas/__init__.py
+++ b/perceval/rendering/canvas/__init__.py
@@ -30,3 +30,4 @@
 from .canvas import Canvas
 from .mplot_canvas import MplotCanvas
 from .svg_canvas import SvgCanvas
+from .latex_canvas import LatexCanvas

--- a/perceval/rendering/canvas/latex_canvas.py
+++ b/perceval/rendering/canvas/latex_canvas.py
@@ -243,11 +243,11 @@ class LatexCanvas(Canvas):
             )
         elif fontstyle == "italic":
             self._draws.append(
-                f"\\node[align={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\itshape\\selectfont}}] at ({points[0]},{-points[1]}) {{{text}}};"
+                f"\\node[anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont\\itshape}}] at ({points[0]},{-points[1]}) {{{text.translate(str.maketrans(latex_greek_letters))}}};"
             )
         elif fontstyle == "bold":
             self._draws.append(
-                f"\\node[align={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\bfseries\\selectfont}}] at ({points[0]},{-points[1]}) {{{text}}};"
+                f"\\node[anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont\\bfseries}}] at ({points[0]},{-points[1]}) {{{text.translate(str.maketrans(latex_greek_letters))}}};"
             )
         else:
             raise NotImplementedError(f"Font style {fontstyle} not implemented")

--- a/perceval/rendering/canvas/latex_canvas.py
+++ b/perceval/rendering/canvas/latex_canvas.py
@@ -29,6 +29,7 @@
 
 from .canvas import Canvas
 
+from copy import copy
 import latexcodec  # noqa
 
 tikz_implemented_colors = {
@@ -154,21 +155,33 @@ class LatexCanvas(Canvas):
                 x_pos, y_pos = points[idx + 1 : idx + 3]
                 idx += 2
             elif points[idx] == "L":
+                x_prev, y_prev = copy(x_end), copy(y_end)
                 x_end, y_end = points[idx + 1 : idx + 3]
-                pathstr += f" ({x_pos},{-y_pos}) -- ({x_end},{-y_end})"
+                if x_prev != x_pos and y_prev != y_pos:
+                    pathstr += f" ({x_pos},{-y_pos}) -- ({x_end},{-y_end})"
+                else:
+                    pathstr += f" -- ({x_end},{-y_end})"
                 x_pos, y_pos = x_end, y_end
                 idx += 2
             elif points[idx] == "S":
+                x_prev, y_prev = copy(x_end), copy(y_end)
                 x_ctl_1, y_ctl_1 = x_ctl_2, y_ctl_2
                 x_ctl_2, y_ctl_2, x_end, y_end = points[idx + 1 : idx + 5]
-                pathstr += f" ({x_pos},{-y_pos}) .. controls ({x_ctl_1},{-y_ctl_1}) and ({x_ctl_2},{-y_ctl_2}) .. ({x_end},{-y_end})"
+                if x_prev != x_pos and y_prev != y_pos:
+                    pathstr += f" ({x_pos},{-y_pos}) .. controls ({x_ctl_1},{-y_ctl_1}) and ({x_ctl_2},{-y_ctl_2}) .. ({x_end},{-y_end})"
+                else:
+                    pathstr += f" .. controls ({x_ctl_1},{-y_ctl_1}) and ({x_ctl_2},{-y_ctl_2}) .. ({x_end},{-y_end})"
                 x_pos, y_pos = x_end, y_end
                 idx += 4
             elif points[idx] == "C":
+                x_prev, y_prev = copy(x_end), copy(y_end)
                 x_ctl_1, y_ctl_1, x_ctl_2, y_ctl_2, x_end, y_end = points[
                     idx + 1 : idx + 7
                 ]
-                pathstr += f" ({x_pos},{-y_pos}) .. controls ({x_ctl_1},{-y_ctl_1}) and ({x_ctl_2},{-y_ctl_2}) .. ({x_end},{-y_end})"
+                if x_prev != x_pos and y_prev != y_pos:
+                    pathstr += f" ({x_pos},{-y_pos}) .. controls ({x_ctl_1},{-y_ctl_1}) and ({x_ctl_2},{-y_ctl_2}) .. ({x_end},{-y_end})"
+                else:
+                    pathstr += f" .. controls ({x_ctl_1},{-y_ctl_1}) and ({x_ctl_2},{-y_ctl_2}) .. ({x_end},{-y_end})"
                 x_pos, y_pos = x_end, y_end
                 idx += 6
             idx += 1

--- a/perceval/rendering/canvas/latex_canvas.py
+++ b/perceval/rendering/canvas/latex_canvas.py
@@ -213,21 +213,22 @@ class LatexCanvas(Canvas):
         elif ta == "right":
             ta = "east"
 
+        text = text.replace("\n", "\\\\ ")
         text = text.encode("latex").decode("utf-8")
 
         points = super().add_text(points, text, size, ta)
 
         if fontstyle == "normal":
             self._draws.append(
-                f"\\node[anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont}}] at ({points[0]},{-points[1]}) {{{text}}};"
+                f"\\node[align=left,anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont}}] at ({points[0]},{-points[1]}) {{{text}}};"
             )
         elif fontstyle == "italic":
             self._draws.append(
-                f"\\node[anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont\\itshape}}] at ({points[0]},{-points[1]}) {{{text}}};"
+                f"\\node[align=left,anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont\\itshape}}] at ({points[0]},{-points[1]}) {{{text}}};"
             )
         elif fontstyle == "bold":
             self._draws.append(
-                f"\\node[anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont\\bfseries}}] at ({points[0]},{-points[1]}) {{{text}}};"
+                f"\\node[align=left,anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont\\bfseries}}] at ({points[0]},{-points[1]}) {{{text}}};"
             )
         else:
             raise NotImplementedError(f"Font style {fontstyle} not implemented")

--- a/perceval/rendering/canvas/latex_canvas.py
+++ b/perceval/rendering/canvas/latex_canvas.py
@@ -220,15 +220,15 @@ class LatexCanvas(Canvas):
 
         if fontstyle == "normal":
             self._draws.append(
-                f"\\node[align=left,anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont}}] at ({points[0]},{-points[1]}) {{{text}}};"
+                f"\\node[align=center,anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont}}] at ({points[0]},{-points[1]}) {{{text}}};"
             )
         elif fontstyle == "italic":
             self._draws.append(
-                f"\\node[align=left,anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont\\itshape}}] at ({points[0]},{-points[1]}) {{{text}}};"
+                f"\\node[align=center,anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont\\itshape}}] at ({points[0]},{-points[1]}) {{{text}}};"
             )
         elif fontstyle == "bold":
             self._draws.append(
-                f"\\node[align=left,anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont\\bfseries}}] at ({points[0]},{-points[1]}) {{{text}}};"
+                f"\\node[align=center,anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont\\bfseries}}] at ({points[0]},{-points[1]}) {{{text}}};"
             )
         else:
             raise NotImplementedError(f"Font style {fontstyle} not implemented")

--- a/perceval/rendering/canvas/latex_canvas.py
+++ b/perceval/rendering/canvas/latex_canvas.py
@@ -1,0 +1,216 @@
+# MIT License
+#
+# Copyright (c) 2022 Quandela
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# As a special exception, the copyright holders of exqalibur library give you
+# permission to combine exqalibur with code included in the standard release of
+# Perceval under the MIT license (or modified versions of such code). You may
+# copy and distribute such a combined system following the terms of the MIT
+# license for both exqalibur and Perceval. This exception for the usage of
+# exqalibur is limited to the python bindings used by Perceval.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from .canvas import Canvas
+
+tikz_implemented_colors = {
+    "red": True,
+    "green": True,
+    "blue": True,
+    "cyan": True,
+    "magenta": True,
+    "yellow": True,
+    "black": True,
+    "gray": True,
+    "white": True,
+    "darkgray": True,
+    "lightgray": True,
+    "brown": True,
+    "lime": True,
+    "olive": True,
+    "orange": True,
+    "pink": True,
+    "purple": True,
+    "teal": True,
+    "violet": True,
+    "darkred": "\\definecolor{darkred}{rgb}{0.55, 0.0, 0.0}",
+    "thistle": "\\definecolor{thistle}{rgb}{0.85, 0.75, 0.85}",
+}
+
+
+class LatexCanvas(Canvas):
+    def __init__(self, **opts):
+        super().__init__(**opts)
+        self._header = [
+            "\\documentclass{standalone}",
+            "\\usepackage{tikz}",
+        ]
+        self._prescript = [
+            "\\begin{document}",
+            "\\begin{tikzpicture}[scale=1.5,x=1pt,y=1pt]",
+        ]
+        self._draws = []
+        self._postscrip = [
+            "\\end{tikzpicture}",
+            "\\end{document}",
+        ]
+        self._color_check_list = tikz_implemented_colors.copy()
+
+    def _check_color_is_implemented(self, color):
+        if self._color_check_list[color] is None:
+            raise NotImplementedError(f"Color {color} is not defined")
+        elif self._color_check_list[color] is not True:
+            self._header.append(self._color_check_list[color])
+            self._color_check_list[color] = True
+
+    def add_mline(
+        self,
+        points,
+        stroke="black",
+        stroke_width=1,
+        stroke_linejoin="miter",
+        stroke_dasharray=None,
+    ):
+        points = super().add_mline(points, stroke, stroke_width)
+        self._check_color_is_implemented(stroke)
+
+        nodes = []
+        for idx in range(0, len(points), 2):
+            nodes.append(f"({points[idx]},{-points[idx+1]})")
+        self._draws.append(
+            f"\draw[color={stroke},line width={stroke_width}] "
+            + " -- ".join(nodes)
+            + ";"
+        )
+
+    def add_polygon(
+        self,
+        points,
+        stroke="black",
+        stroke_width=1,
+        fill=None,
+        stroke_linejoin="miter",
+        stroke_dasharray=None,
+    ):
+        points = super().add_polygon(points, stroke, stroke_width, fill)
+        self._check_color_is_implemented(stroke)
+        if fill is None:
+            fill = "none"
+        else:
+            self._check_color_is_implemented(fill)
+
+        nodes = []
+        for idx in range(0, len(points), 2):
+            nodes.append(f"({points[idx]},{-points[idx+1]})")
+        self._draws.append(
+            f"\draw[color={stroke},line width={stroke_width},fill={fill}] "
+            + " -- ".join(nodes)
+            + " -- cycle;"
+        )
+
+    def add_mpath(
+        self,
+        points,
+        stroke="black",
+        stroke_width=1,
+        fill=None,
+        stroke_linejoin="miter",
+        stroke_dasharray=None,
+    ):
+        points = super().add_mpath(points, stroke, stroke_width, fill)
+        self._check_color_is_implemented(stroke)
+        if fill is None:
+            fill = "none"
+        else:
+            self._check_color_is_implemented(fill)
+
+        pathstr = f"\draw[color={stroke},line width={stroke_width},line join={stroke_linejoin},fill={fill}]"
+        idx = 0
+        x_pos, y_pos = 0, 0
+        while idx < len(points):
+            if points[idx] == "M":
+                x_pos, y_pos = points[idx + 1 : idx + 3]
+                idx += 2
+            elif points[idx] == "L":
+                x_end, y_end = points[idx + 1 : idx + 3]
+                pathstr += f" ({x_pos},{-y_pos}) -- ({x_end},{-y_end})"
+                x_pos, y_pos = x_end, y_end
+                idx += 2
+            elif points[idx] == "S":
+                x_ctl_1, y_ctl_1 = x_ctl_2, y_ctl_2
+                x_ctl_2, y_ctl_2, x_end, y_end = points[idx + 1 : idx + 5]
+                pathstr += f" ({x_pos},{-y_pos}) .. controls ({x_ctl_1},{-y_ctl_1}) and ({x_ctl_2},{-y_ctl_2}) .. ({x_end},{-y_end})"
+                x_pos, y_pos = x_end, y_end
+                idx += 4
+            elif points[idx] == "C":
+                x_ctl_1, y_ctl_1, x_ctl_2, y_ctl_2, x_end, y_end = points[
+                    idx + 1 : idx + 7
+                ]
+                pathstr += f" ({x_pos},{-y_pos}) .. controls ({x_ctl_1},{-y_ctl_1}) and ({x_ctl_2},{-y_ctl_2}) .. ({x_end},{-y_end})"
+                x_pos, y_pos = x_end, y_end
+                idx += 6
+            idx += 1
+
+        self._draws.append(pathstr + ";")
+
+    def add_circle(
+        self,
+        points,
+        r,
+        stroke="black",
+        stroke_width=1,
+        fill=None,
+        stroke_dasharray=None,
+    ):
+        points = super().add_circle(points, r, stroke, stroke_width, fill)
+        if fill is None:
+            fill = "none"
+
+        self._draws.append(
+            f"\draw[color={stroke},line width={stroke_width},line join={stroke_linejoin},fill={fill}] ({points[0]},{points[1]}) circle[radius={r}];"
+        )
+
+    def add_text(self, points, text, size, ta="left", fontstyle="normal"):
+        if ta == "middle":
+            ta = "mid"
+        elif ta == "left":
+            ta = "west"
+        elif ta == "right":
+            ta = "east"
+
+        points = super().add_text(points, text, size, ta)
+
+        if fontstyle == "normal":
+            self._draws.append(
+                f"\\node[anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}}}] at ({points[0]},{-points[1]}) {{{text}}};"
+            )
+        elif fontstyle == "italic":
+            self._draws.append(
+                f"\\node[align={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\itshape}}] at ({points[0]},{-points[1]}) {{{text}}};"
+            )
+        elif fontstyle == "bold":
+            self._draws.append(
+                f"\\node[align={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\bfseries}}] at ({points[0]},{-points[1]}) {{{text}}};"
+            )
+        else:
+            raise NotImplementedError(f"Font style {fontstyle} not implemented")
+
+    def draw(self):
+        super().draw()
+        return "\n".join(self._header + self._prescript + self._draws + self._postscrip)

--- a/perceval/rendering/canvas/latex_canvas.py
+++ b/perceval/rendering/canvas/latex_canvas.py
@@ -29,6 +29,8 @@
 
 from .canvas import Canvas
 
+import latexcodec  # noqa
+
 tikz_implemented_colors = {
     "aquamarine": "\\definecolor{aquamarine}{rgb}{0.5, 1.0, 0.83}",
     "black": True,
@@ -55,43 +57,6 @@ tikz_implemented_colors = {
     "violet": True,
     "white": True,
     "yellow": True,
-}
-
-latex_greek_letters = {
-    "α": "$\\alpha$",
-    "β": "$\\beta$",
-    "γ": "$\\gamma$",
-    "δ": "$\\delta$",
-    "ϵ": "$\\epsilon$",
-    "ζ": "$\\zeta$",
-    "η": "$\\eta$",
-    "θ": "$\\theta$",
-    "ι": "$\\iota$",
-    "κ": "$\\kappa$",
-    "λ": "$\\lambda$",
-    "μ": "$\\mu$",
-    "ν": "$\\nu$",
-    "ξ": "$\\xi$",
-    "π": "$\\pi$",
-    "ρ": "$\\rho$",
-    "σ": "$\\sigma$",
-    "τ": "$\\tau$",
-    "υ": "$\\upsilon$",
-    "ϕ": "$\\phi$",
-    "χ": "$\\chi$",
-    "ψ": "$\\psi$",
-    "ω": "$\\omega$",
-    "Γ": "$\\Gamma$",
-    "Δ": "$\\Delta$",
-    "Θ": "$\\Theta$",
-    "Λ": "$\\Lambda$",
-    "Ξ": "$\\Xi$",
-    "Π": "$\\Pi$",
-    "Σ": "$\\Sigma$",
-    "Υ": "$\\Upsilon$",
-    "Φ": "$\\Phi$",
-    "Ψ": "$\\Psi$",
-    "Ω": "$\\Omega$",
 }
 
 
@@ -235,19 +200,21 @@ class LatexCanvas(Canvas):
         elif ta == "right":
             ta = "east"
 
+        text = text.encode("latex").decode("utf-8")
+
         points = super().add_text(points, text, size, ta)
 
         if fontstyle == "normal":
             self._draws.append(
-                f"\\node[anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont}}] at ({points[0]},{-points[1]}) {{{text.translate(str.maketrans(latex_greek_letters))}}};"
+                f"\\node[anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont}}] at ({points[0]},{-points[1]}) {{{text}}};"
             )
         elif fontstyle == "italic":
             self._draws.append(
-                f"\\node[anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont\\itshape}}] at ({points[0]},{-points[1]}) {{{text.translate(str.maketrans(latex_greek_letters))}}};"
+                f"\\node[anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont\\itshape}}] at ({points[0]},{-points[1]}) {{{text}}};"
             )
         elif fontstyle == "bold":
             self._draws.append(
-                f"\\node[anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont\\bfseries}}] at ({points[0]},{-points[1]}) {{{text.translate(str.maketrans(latex_greek_letters))}}};"
+                f"\\node[anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont\\bfseries}}] at ({points[0]},{-points[1]}) {{{text}}};"
             )
         else:
             raise NotImplementedError(f"Font style {fontstyle} not implemented")

--- a/perceval/rendering/canvas/latex_canvas.py
+++ b/perceval/rendering/canvas/latex_canvas.py
@@ -142,7 +142,7 @@ class LatexCanvas(Canvas):
 
         pathstr = f"\draw[color={stroke},line width={stroke_width},line join={stroke_linejoin},fill={fill}]"
         idx = 0
-        x_pos, y_pos = 0, 0
+        x_pos = y_pos = x_ctl_1 = y_ctl_1 = x_ctl_2 = y_ctl_2 = x_end = y_end = 0
         while idx < len(points):
             if points[idx] == "M":
                 x_pos, y_pos = points[idx + 1 : idx + 3]
@@ -183,7 +183,7 @@ class LatexCanvas(Canvas):
             fill = "none"
 
         self._draws.append(
-            f"\draw[color={stroke},line width={stroke_width},line join={stroke_linejoin},fill={fill}] ({points[0]},{points[1]}) circle[radius={r}];"
+            f"\draw[color={stroke},line width={stroke_width},fill={fill}] ({points[0]},{points[1]}) circle[radius={r}];"
         )
 
     def add_text(self, points, text, size, ta="left", fontstyle="normal"):

--- a/perceval/rendering/canvas/latex_canvas.py
+++ b/perceval/rendering/canvas/latex_canvas.py
@@ -30,27 +30,68 @@
 from .canvas import Canvas
 
 tikz_implemented_colors = {
-    "red": True,
-    "green": True,
-    "blue": True,
-    "cyan": True,
-    "magenta": True,
-    "yellow": True,
+    "aquamarine": "\\definecolor{aquamarine}{rgb}{0.5, 1.0, 0.83}",
     "black": True,
-    "gray": True,
-    "white": True,
-    "darkgray": True,
-    "lightgray": True,
+    "blue": True,
     "brown": True,
+    "cyan": True,
+    "darkgray": True,
+    "darkred": "\\definecolor{darkred}{rgb}{0.55, 0.0, 0.0}",
+    "gray": True,
+    "green": True,
+    "lightblue": "\\definecolor{lightblue}{rgb}{0.68, 0.85, 0.9}",
+    "lightgray": True,
+    "lightpink": "\\definecolor{lightpink}{rgb}{1.0, 0.71, 0.76}",
+    "lightyellow": "\\definecolor{lightyellow}{rgb}{1.0, 1.0, 0.88}",
     "lime": True,
+    "magenta": True,
     "olive": True,
     "orange": True,
     "pink": True,
     "purple": True,
+    "red": True,
     "teal": True,
-    "violet": True,
-    "darkred": "\\definecolor{darkred}{rgb}{0.55, 0.0, 0.0}",
     "thistle": "\\definecolor{thistle}{rgb}{0.85, 0.75, 0.85}",
+    "violet": True,
+    "white": True,
+    "yellow": True,
+}
+
+latex_greek_letters = {
+    "α": "$\\alpha$",
+    "β": "$\\beta$",
+    "γ": "$\\gamma$",
+    "δ": "$\\delta$",
+    "ϵ": "$\\epsilon$",
+    "ζ": "$\\zeta$",
+    "η": "$\\eta$",
+    "θ": "$\\theta$",
+    "ι": "$\\iota$",
+    "κ": "$\\kappa$",
+    "λ": "$\\lambda$",
+    "μ": "$\\mu$",
+    "ν": "$\\nu$",
+    "ξ": "$\\xi$",
+    "π": "$\\pi$",
+    "ρ": "$\\rho$",
+    "σ": "$\\sigma$",
+    "τ": "$\\tau$",
+    "υ": "$\\upsilon$",
+    "ϕ": "$\\phi$",
+    "χ": "$\\chi$",
+    "ψ": "$\\psi$",
+    "ω": "$\\omega$",
+    "Γ": "$\\Gamma$",
+    "Δ": "$\\Delta$",
+    "Θ": "$\\Theta$",
+    "Λ": "$\\Lambda$",
+    "Ξ": "$\\Xi$",
+    "Π": "$\\Pi$",
+    "Σ": "$\\Sigma$",
+    "Υ": "$\\Upsilon$",
+    "Φ": "$\\Phi$",
+    "Ψ": "$\\Psi$",
+    "Ω": "$\\Omega$",
 }
 
 
@@ -60,20 +101,21 @@ class LatexCanvas(Canvas):
         self._header = [
             "\\documentclass{standalone}",
             "\\usepackage{tikz}",
+            # "\\usepackage{lmodern}",
         ]
         self._prescript = [
             "\\begin{document}",
-            "\\begin{tikzpicture}[scale=1.5,x=1pt,y=1pt]",
+            "\\begin{tikzpicture}[scale=1.0,x=1pt,y=1pt]",
         ]
         self._draws = []
-        self._postscrip = [
+        self._postscript = [
             "\\end{tikzpicture}",
             "\\end{document}",
         ]
         self._color_check_list = tikz_implemented_colors.copy()
 
     def _check_color_is_implemented(self, color):
-        if self._color_check_list[color] is None:
+        if color not in self._color_check_list:
             raise NotImplementedError(f"Color {color} is not defined")
         elif self._color_check_list[color] is not True:
             self._header.append(self._color_check_list[color])
@@ -94,7 +136,7 @@ class LatexCanvas(Canvas):
         for idx in range(0, len(points), 2):
             nodes.append(f"({points[idx]},{-points[idx+1]})")
         self._draws.append(
-            f"\draw[color={stroke},line width={stroke_width}] "
+            f"\\draw[color={stroke},line width={stroke_width}] "
             + " -- ".join(nodes)
             + ";"
         )
@@ -119,7 +161,7 @@ class LatexCanvas(Canvas):
         for idx in range(0, len(points), 2):
             nodes.append(f"({points[idx]},{-points[idx+1]})")
         self._draws.append(
-            f"\draw[color={stroke},line width={stroke_width},fill={fill}] "
+            f"\\draw[color={stroke},line width={stroke_width},fill={fill}] "
             + " -- ".join(nodes)
             + " -- cycle;"
         )
@@ -140,7 +182,7 @@ class LatexCanvas(Canvas):
         else:
             self._check_color_is_implemented(fill)
 
-        pathstr = f"\draw[color={stroke},line width={stroke_width},line join={stroke_linejoin},fill={fill}]"
+        pathstr = f"\\draw[color={stroke},line width={stroke_width},line join={stroke_linejoin},fill={fill}]"
         idx = 0
         x_pos = y_pos = x_ctl_1 = y_ctl_1 = x_ctl_2 = y_ctl_2 = x_end = y_end = 0
         while idx < len(points):
@@ -183,12 +225,12 @@ class LatexCanvas(Canvas):
             fill = "none"
 
         self._draws.append(
-            f"\draw[color={stroke},line width={stroke_width},fill={fill}] ({points[0]},{points[1]}) circle[radius={r}];"
+            f"\\draw[color={stroke},line width={stroke_width},fill={fill}] ({points[0]},{points[1]}) circle[radius={r}];"
         )
 
     def add_text(self, points, text, size, ta="left", fontstyle="normal"):
         if ta == "middle":
-            ta = "mid"
+            ta = "base"
         elif ta == "left":
             ta = "west"
         elif ta == "right":
@@ -198,19 +240,21 @@ class LatexCanvas(Canvas):
 
         if fontstyle == "normal":
             self._draws.append(
-                f"\\node[anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}}}] at ({points[0]},{-points[1]}) {{{text}}};"
+                f"\\node[anchor={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\selectfont}}] at ({points[0]},{-points[1]}) {{{text.translate(str.maketrans(latex_greek_letters))}}};"
             )
         elif fontstyle == "italic":
             self._draws.append(
-                f"\\node[align={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\itshape}}] at ({points[0]},{-points[1]}) {{{text}}};"
+                f"\\node[align={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\itshape\\selectfont}}] at ({points[0]},{-points[1]}) {{{text}}};"
             )
         elif fontstyle == "bold":
             self._draws.append(
-                f"\\node[align={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\bfseries}}] at ({points[0]},{-points[1]}) {{{text}}};"
+                f"\\node[align={ta},font = {{\\fontsize{{{size}pt}}{{0}}\\bfseries\\selectfont}}] at ({points[0]},{-points[1]}) {{{text}}};"
             )
         else:
             raise NotImplementedError(f"Font style {fontstyle} not implemented")
 
     def draw(self):
         super().draw()
-        return "\n".join(self._header + self._prescript + self._draws + self._postscrip)
+        return "\n".join(
+            self._header + self._prescript + self._draws + self._postscript
+        )

--- a/perceval/rendering/canvas/latex_canvas.py
+++ b/perceval/rendering/canvas/latex_canvas.py
@@ -101,7 +101,6 @@ class LatexCanvas(Canvas):
         self._header = [
             "\\documentclass{standalone}",
             "\\usepackage{tikz}",
-            # "\\usepackage{lmodern}",
         ]
         self._prescript = [
             "\\begin{document}",

--- a/perceval/rendering/circuit/renderer.py
+++ b/perceval/rendering/circuit/renderer.py
@@ -34,7 +34,7 @@ from typing import Any, Tuple
 
 from perceval.rendering.circuit import ASkin, ModeStyle
 from perceval.rendering.format import Format
-from perceval.rendering.canvas import Canvas, MplotCanvas, SvgCanvas
+from perceval.rendering.canvas import Canvas, MplotCanvas, SvgCanvas, LatexCanvas
 from perceval.components import ACircuit, Circuit, PortLocation, PERM, Herald
 from perceval.utils.format import format_parameters
 
@@ -561,12 +561,12 @@ def create_renderer(
     """
     if output_format == Format.TEXT:
         return TextRenderer(n)
-    if output_format == Format.LATEX:
-        raise NotImplementedError("Latex format is not supported for circuit rendering")
-
+    
     assert skin is not None, "A skin must be selected for circuit graphical rendering"
     if output_format == Format.HTML:
         canvas = SvgCanvas(**opts)
+    elif output_format == Format.LATEX:
+        canvas = LatexCanvas(**opts)
     else:
         canvas = MplotCanvas(**opts)
     return CanvasRenderer(n, canvas, skin)

--- a/perceval/rendering/pdisplay.py
+++ b/perceval/rendering/pdisplay.py
@@ -289,7 +289,7 @@ def pdisplay(o, output_format: Format = None, **opts):
 
     if isinstance(res, drawsvg.Drawing):
         return res
-    elif in_notebook and output_format != Format.TEXT:
+    elif in_notebook and output_format != Format.TEXT and output_format != Format.LATEX:
         display(HTML(res))
     else:
         print(res)
@@ -323,6 +323,11 @@ def pdisplay_to_file(o, path: str, output_format: Format = None, **opts):
             return
         except:
             pass
+    
+    if output_format == Format.LATEX:
+        with open(path, 'w', encoding='utf-8') as f_out:
+            f_out.write(res)
+        return
 
     warnings.warn(
         f"No output file could be created for {type(o)} object (format = {output_format.name}) at path {path}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ Deprecated
 requests
 drawsvg>=2.0
 protobuf>=4.21.2
+latexcodec

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-exqalibur~=0.1.0
+exqalibur~=0.1.1
 tabulate
 pytest
 setuptools
@@ -12,4 +12,5 @@ Deprecated
 requests
 drawsvg>=2.0
 protobuf>=4.21.2
+networkx~=3.1
 latexcodec


### PR DESCRIPTION
# Summary
- Resolve #206

## Details
- Running `pcvl.pdisplay(circuit, output_format=pcvl.rendering.Format.LATEX)` will output a series of LaTeX commands.

## Example
```python
import perceval as pcvl
import perceval.components.unitary_components as comp

mzi = (pcvl.Circuit(m=2, name="mzi")
       .add((0, 1), comp.BS())
       .add(0, comp.PS(pcvl.Parameter("phi1")))
       .add((0, 1), comp.BS())
       .add(0, comp.PS(pcvl.Parameter("phi2"))))

pcvl.pdisplay(mzi, output_format=pcvl.rendering.Format.LATEX)
```
Output:
```latex
\documentclass{standalone}
\usepackage{tikz}
\definecolor{darkred}{rgb}{0.55, 0.0, 0.0}
\definecolor{thistle}{rgb}{0.85, 0.75, 0.85}
\begin{document}
\begin{tikzpicture}[scale=1.5,x=1pt,y=1pt]
\draw[color=darkred,line width=3,line join=miter,fill=none] (10,-25) -- (25,-25);
\draw[color=darkred,line width=3,line join=miter,fill=none] (10,-75) -- (25,-75);
\draw[color=darkred,line width=3] (25,-25) -- (53,-25) -- (72,-44);
\draw[color=darkred,line width=3] (78,-44) -- (97,-25) -- (125,-25);
\draw[color=darkred,line width=3] (25,-75) -- (53,-75) -- (72,-56);
\draw[color=darkred,line width=3] (78,-56) -- (97,-75) -- (125,-75);
\draw[color=black,line width=1,fill=black] (50,-43) -- (100,-43) -- (100,-57) -- (50,-57) -- cycle;
\node[anchor=mid,font = {\fontsize{7pt}{0}}] at (75,-85) {};
\node[anchor=mid,font = {\fontsize{7pt}{0}}] at (75,-26) {};
\draw[color=black,line width=1,fill=lightgray] (50,-43) -- (100,-43) -- (100,-47) -- (50,-47) -- cycle;
\draw[color=black,line width=1,fill=thistle] (93,-50) -- (103,-50) -- (103,-60) -- (93,-60) -- cycle;
\node[anchor=mid,font = {\fontsize{6pt}{0}}] at (98,-57) {Rx};
\draw[color=darkred,line width=3] (125,-25) -- (175,-25);
\draw[color=black,line width=1,fill=gray] (130,-40) -- (139,-40) -- (153,-10) -- (144,-10) -- (130,-40) -- (139,-40) -- cycle;
\node[anchor=west,font = {\fontsize{7pt}{0}}] at (147,-38) {Φ=phi1};
\draw[color=darkred,line width=3] (125,-75) -- (175,-75);
\draw[color=darkred,line width=3] (175,-25) -- (203,-25) -- (222,-44);
\draw[color=darkred,line width=3] (228,-44) -- (247,-25) -- (275,-25);
\draw[color=darkred,line width=3] (175,-75) -- (203,-75) -- (222,-56);
\draw[color=darkred,line width=3] (228,-56) -- (247,-75) -- (275,-75);
\draw[color=black,line width=1,fill=black] (200,-43) -- (250,-43) -- (250,-57) -- (200,-57) -- cycle;
\node[anchor=mid,font = {\fontsize{7pt}{0}}] at (225,-85) {};
\node[anchor=mid,font = {\fontsize{7pt}{0}}] at (225,-26) {};
\draw[color=black,line width=1,fill=lightgray] (200,-43) -- (250,-43) -- (250,-47) -- (200,-47) -- cycle;
\draw[color=black,line width=1,fill=thistle] (243,-50) -- (253,-50) -- (253,-60) -- (243,-60) -- cycle;
\node[anchor=mid,font = {\fontsize{6pt}{0}}] at (248,-57) {Rx};
\draw[color=darkred,line width=3] (275,-25) -- (325,-25);
\draw[color=black,line width=1,fill=gray] (280,-40) -- (289,-40) -- (303,-10) -- (294,-10) -- (280,-40) -- (289,-40) -- cycle;
\node[anchor=west,font = {\fontsize{7pt}{0}}] at (297,-38) {Φ=phi2};
\draw[color=darkred,line width=3] (275,-75) -- (325,-75);
\draw[color=darkred,line width=3,line join=miter,fill=none] (325,-25) -- (340,-25);
\draw[color=darkred,line width=3,line join=miter,fill=none] (325,-75) -- (340,-75);
\node[anchor=east,font = {\fontsize{6pt}{0}}] at (350,-28) {0};
\node[anchor=east,font = {\fontsize{6pt}{0}}] at (350,-78) {1};
\node[anchor=west,font = {\fontsize{6pt}{0}}] at (0,-28) {0};
\node[anchor=west,font = {\fontsize{6pt}{0}}] at (0,-78) {1};
\end{tikzpicture}
\end{document}
```
Run 
```bash
$ lualatex file.tex
```
to create pdf file.

![codetest](https://github.com/Quandela/Perceval/assets/103920010/14bdcb58-73b3-4d1e-94ab-9b3dd45d01ec)