### PR TITLE
Perceval 0.9.x

### DIFF
--- a/perceval/utils/parameter.py
+++ b/perceval/utils/parameter.py
@@ -114,7 +114,7 @@ class Parameter:
                 p = int((min_v-v)/(max_v-min_v))
                 v = v + (p+1) * (max_v-min_v)
         if (min_v is not None and v < min_v) or (max_v is not None and v > max_v):
-            raise ValueError("value %f out of bound [%f,%f]", v, min_v, max_v)
+            raise ValueError("value %f out of bound [%f,%f]" %(v, min_v, max_v))
         return v
 
     def check_value(self, v):

--- a/perceval/utils/polarization.py
+++ b/perceval/utils/polarization.py
@@ -59,7 +59,7 @@ class Polarization:
             elif v == "L":
                 self.theta_phi = (sp.pi/2, sp.pi/2)
             else:
-                raise ValueError("undefined value '%s' for polarization")
+                raise ValueError("undefined value '%s' for polarization" %v)
         elif isinstance(v, tuple):
             if len(v) != 2:
                 raise ValueError("Polarization is defined by 2 angles")


### PR DESCRIPTION
This PR fixes few tiny mistakes with error reporting.

- perceval/utils/polarization.py  valuerror line 62, missing the variable https://github.com/Quandela/Perceval/blob/a26b0bd8d012e39a549b2abf145d48448689c5fe/perceval/utils/polarization.py#L62
- fix f-string syntax error to properly replace variables in bounds check, https://github.com/Quandela/Perceval/blob/a26b0bd8d012e39a549b2abf145d48448689c5fe/perceval/utils/parameter.py#L117