### PR TITLE
DRAFT: [docs] sphinx multiversion

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yml
+++ b/.github/workflows/build-and-deploy-docs.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Build docs
       run: |
         cd docs
-        make html
+        make multiversion
 
     - name: Install SSH Key
       uses: shimataro/ssh-key-action@v2

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,3 +18,10 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+multiversion:
+	python -m sphinx_multiversion source build/html
+
+clean: rm -rf build
+
+.PHONY: clean 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,10 @@
 wheel
 sphinx==6.2.1
-sphinx-rtd-theme
+sphinx_rtd_theme
 sphinxcontrib-bibtex
-sphinx-autodoc-typehints
+sphinx_autodoc_typehints
 nbsphinx
 jinja2==3.0.0
 ipython
+sphinx_multiversion
+gitpython

--- a/docs/source/_templates/page.html
+++ b/docs/source/_templates/page.html
@@ -1,0 +1,11 @@
+{% extends "!page.html" %} {% block body %} {% if current_version and
+latest_version and current_version != latest_version %}
+<p style="background-color: #ffc300; border: 1px solid #b87333; padding: 10px">
+  <strong>
+    You're reading the documentation of the
+    <a href="./">{{current_version.name}}</a>. For the latest released version,
+    please have a look at
+    <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name}}</a>.
+  </strong>
+</p>
+{% endif %} {{ super() }} {% endblock %}%

--- a/docs/source/_templates/versions.html
+++ b/docs/source/_templates/versions.html
@@ -1,0 +1,31 @@
+{%- if current_version %}
+<div
+  class="rst-versions"
+  data-toggle="rst-versions"
+  role="note"
+  aria-label="versions"
+>
+  <span class="rst-current-version" data-toggle="rst-current-version">
+    <span class="fa fa-book"> Other Versions</span>
+    v: {{ current_version.name }}
+    <span class="fa fa-caret-down"></span>
+  </span>
+  <div class="rst-other-versions">
+    {%- if versions.tags %}
+    <dl>
+      <dt>Tags</dt>
+      {%- for item in versions.tags %}
+      <dd><a href="{{ item.url }}">{{ item.name }}</a></dd>
+      {%- endfor %}
+    </dl>
+    {%- endif %} {%- if versions.branches %}
+    <dl>
+      <dt>Branches</dt>
+      {%- for item in versions.branches %}
+      <dd><a href="{{ item.url }}">{{ item.name }}</a></dd>
+      {%- endfor %}
+    </dl>
+    {%- endif %}
+  </div>
+</div>
+{%- endif %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,17 +41,24 @@
 #
 import os
 import sys
+import git
+from datetime import datetime
+
 sys.path.insert(0, os.path.relpath('../'))
 
 
 # -- Project information -----------------------------------------------------
 
 project = 'perceval'
-copyright = '2022, Quandela'
+copyright = f"{datetime.now().year}, Quandela"
 author = 'Jean Senellart'
 
+repo = git.Repo('../..')
+tags = sorted(repo.tags, key=lambda t: t.commit.committed_datetime)
+latest_tag = f"{tags[-1]}"
+
 # The full version, including alpha/beta/rc tags
-release = '0.9.0'
+release = latest_tag[1:]
 
 
 # -- General configuration ---------------------------------------------------
@@ -66,7 +73,22 @@ extensions = [
     'sphinx.ext.autosectionlabel',
     'sphinxcontrib.bibtex',
     'nbsphinx',
+    'sphinx_multiversion',
 ]
+
+# Whitelist pattern for tags (set to None to ignore all tags)
+smv_tag_whitelist = r'^v\d+\.\d+.*$|latest'
+
+# Whitelist pattern for branches (set to None to ignore all branches)
+smv_branch_whitelist = None
+
+# Whitelist pattern for remotes (set to None to use local branches only)
+smv_remote_whitelist = None
+
+# Pattern for released versions
+smv_released_pattern = r'v.*'
+
+smv_latest_version = latest_tag
 
 bibtex_bibfiles = ['references.bib']
 bibtex_reference_style = 'author_year'


### PR DESCRIPTION
It's a draft because it's missing the `index.html` which redirect to the correct version

Something like this to add in the CI

```jinja
<!DOCTYPE html>
<html>
  <head>
    <title>Redirecting to master branch</title>
    <meta charset="utf-8">
    <meta http-equiv="refresh" content="0; url=./{{latest}}">
    <link rel="canonical" href="{{latest}}">
  </head>
  <body>
  <p>Redirecting you to <a href="./{{latest}}">{{latest}}</a></p>
  </body>
</html>
````