### PR TITLE
PCVL-576 Fix cloud error when RemoteProcessor is empty

### DIFF
--- a/perceval/runtime/remote_processor.py
+++ b/perceval/runtime/remote_processor.py
@@ -158,7 +158,7 @@ class RemoteProcessor(AProcessor):
             'command': command,
             **kwargs
         }
-        if self._components and not circuitless:
+        if not circuitless:
             payload['circuit'] = serialize(self.linear_circuit())
         if self._input_state and not inputless:
             payload['input_state'] = serialize(self._input_state)


### PR DESCRIPTION
When a RemoteProcessor has no component, it still sends an identity circuit of the correct size in its payload