### PR TITLE
Pcvl 636 fix invalid sv syntax in simulator

### DIFF
--- a/perceval/simulators/simulator.py
+++ b/perceval/simulators/simulator.py
@@ -132,7 +132,7 @@ class Simulator(ISimulator):
     @dispatch(StateVector, BasicState)
     def prob_amplitude(self, input_state: StateVector, output_state: BasicState) -> complex:
         result = complex(0)
-        for state, pa in input_state.items():
+        for state, pa in input_state:
             result += self.prob_amplitude(state, output_state) * pa
         return result
 
@@ -162,7 +162,7 @@ class Simulator(ISimulator):
         output_state.clear_annotations()
         sv_out = self.evolve(input_state)  # This is not as optimized as it could be
         result = 0
-        for state, pa in sv_out.items():
+        for state, pa in sv_out:
             state.clear_annotations()
             if state == output_state:
                 result += abs(pa) ** 2

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -185,6 +185,15 @@ def test_simulator_probampli():
     # prob_amplitude call is strict on annotations name
     assert simulator.prob_amplitude(input_state, BasicState("|{_:0}{_:2},0>")) == pytest.approx(0)
 
+    input_state = StateVector("|{_:0},{_:1}>")
+    assert simulator.prob_amplitude(input_state, BasicState("|{_:0}{_:1},0>")) == pytest.approx(0.5j)
+    assert simulator.prob_amplitude(input_state, BasicState("|0,{_:0}{_:1}>")) == pytest.approx(0.5j)
+    assert simulator.prob_amplitude(input_state, BasicState("|{_:0},{_:1}>")) == pytest.approx(0.5)
+    assert simulator.prob_amplitude(input_state, BasicState("|{_:1},{_:0}>")) == pytest.approx(-0.5)
+    assert simulator.prob_amplitude(input_state, BasicState("|2,0>")) == pytest.approx(0)
+    assert simulator.prob_amplitude(input_state, BasicState("|1,1>")) == pytest.approx(0)
+    # prob_amplitude call is strict on annotations name
+    assert simulator.prob_amplitude(input_state, BasicState("|{_:0}{_:2},0>")) == pytest.approx(0)
 
 def test_simulator_probability():
     input_state = BasicState("|{_:0},{_:1}>")
@@ -201,6 +210,12 @@ def test_simulator_probability():
     assert simulator.probability(input_state, BasicState("|2,0>")) == pytest.approx(0.5)
     assert simulator.probability(input_state, BasicState("|0,2>")) == pytest.approx(0.5)
     assert simulator.probability(input_state, BasicState("|1,1>")) == pytest.approx(0.0)
+
+    input_state = StateVector("|{_:0},{_:1}>")
+    assert simulator.probability(input_state, BasicState("|{_:0}{_:1},0>")) == pytest.approx(0.25)
+    assert simulator.probability(input_state, BasicState("|2,0>")) == pytest.approx(0.25)
+    assert simulator.probability(input_state, BasicState("|0,2>")) == pytest.approx(0.25)
+    assert simulator.probability(input_state, BasicState("|1,1>")) == pytest.approx(0.5)
 
 
 def test_simulator_probs_sv():


### PR DESCRIPTION
I have made two commits:

- I changed two functions in simulator.py
- I extend tow test function correspondingly in test_simulator.py