### PR TITLE
Update Scaleway

### DIFF
--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -58,8 +58,31 @@ Note: using a ``with`` block you do not need to start and stop your session: it 
 
 Note: while using a Jupyter Notebook for convenience python objects are kept alive and we recommand using directly ``start`` and ``stop`` methods.
 
-From a session, you can instantiate a ``RemoteProcessor`` linked to the session:
+Using an existing Scaleway session
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+If you created your session from the `Scaleway console <https://console.scaleway.com/qaas>`_, you can retrieve it from Perceval.
+
+For this, you only have to go to your session's settings on the console, copy the deduplication identifier and put it to the session creation on your Perceval code.
+
+>>> DEDUPLICATION_ID = "my-quantum-workshop-identifier"
+>>> session = scw.Session(platform=PLATFORM_NAME, project_id=PROJECT_ID, token=TOKEN, deduplication_id=DEDUPLICATION_ID)
+
+A session can be fetched until termination or timeout. If there is no alive session matching the deduplication_id, a new one will be created and returned. 
+It is highly convenient if you wish to keep a specific amount of session alive at a time.
+
+Send a circuit to a Scaleway session
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Now you are handling a session, you can instantiate a ``RemoteProcessor`` linked to the session:
 
 >>> processor = session.build_remote_processor()
+
+Then, we can attached a toy circuit to send on our session
+
+>>> processor.set_circuit(pcvl.Circuit(m=2, name="a-toy-circuit") // pcvl.BS.H())
+>>> processor.with_input(pcvl.BasicState("|0,1>"))
+>>> sampler = pcvl.algorithm.Sampler(processor, max_shots_per_call=10_000)
+>>> job = sampler.samples(100)
+>>> print(job)
 
 Congratulation you can now design and send jobs to Scaleway QaaS through your processor. You can continue with the documentation through :ref:`Work with algorithms`.

--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -67,7 +67,7 @@ For this, you only have to go to your session's settings on the console, copy th
 >>> DEDUPLICATION_ID = "my-quantum-workshop-identifier"
 >>> session = scw.Session(platform=PLATFORM_NAME, project_id=PROJECT_ID, token=TOKEN, deduplication_id=DEDUPLICATION_ID)
 
-A session can be fetched until termination or timeout. If there is no alive session matching the deduplication_id, a new one will be created and returned. 
+A session can be fetched until termination or timeout. If there is no alive session matching the deduplication_id, a new one will be created and returned.
 It is highly convenient if you wish to keep a specific amount of session alive at a time.
 
 Send a circuit to a Scaleway session
@@ -77,7 +77,7 @@ Now you are handling a session, you can instantiate a ``RemoteProcessor`` linked
 
 >>> processor = session.build_remote_processor()
 
-Then, we can attached a toy circuit to send on our session
+Then, we can attach a toy circuit and send it on our session
 
 >>> processor.set_circuit(pcvl.Circuit(m=2, name="a-toy-circuit") // pcvl.BS.H())
 >>> processor.with_input(pcvl.BasicState("|0,1>"))

--- a/perceval/providers/scaleway/scaleway_rpc_handler.py
+++ b/perceval/providers/scaleway/scaleway_rpc_handler.py
@@ -28,14 +28,13 @@
 # SOFTWARE.
 import urllib
 import time
-from datetime import datetime, timedelta
-import json
-from typing import Union
-
-
-from enum import Enum
 import requests
+import json
+
+from datetime import datetime, timedelta
 from requests import HTTPError
+from typing import Union
+from enum import Enum
 
 _PROVIDER_NAME = "quandela"
 _ENDPOINT_PLATFORM = "/platforms"
@@ -152,10 +151,10 @@ class RPCHandler:
         )
 
         return {
-            "duration": duration,
+            "duration": resp_dict.get("job_duration", duration),
             "intermediate_results": [],
             "job_id": resp_dict.get("id"),
-            "results": json.dumps(resp_dict.get("result_distribution", {})),
+            "results": resp_dict.get("result_distribution", {}),
             "results_type": None,
         }
 

--- a/perceval/providers/scaleway/scaleway_session.py
+++ b/perceval/providers/scaleway/scaleway_session.py
@@ -26,11 +26,11 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import requests
+
 from perceval.runtime import ISession
 from perceval.runtime.remote_processor import RemoteProcessor
 from .scaleway_rpc_handler import RPCHandler
-
-import requests
 from requests import HTTPError
 
 _ENDPOINT_URL = "https://api.scaleway.com/qaas/v1alpha1"
@@ -108,8 +108,8 @@ class Session(ISession):
             raise HTTPError(request.json())
 
     def stop(self) -> None:
-        endpoint = f"{self._url}{_ENDPOINT_SESSION}/{self._session_id}"
-        request = requests.delete(endpoint, headers=self._headers)
+        endpoint = f"{self._url}{_ENDPOINT_SESSION}/{self._session_id}/terminate"
+        request = requests.post(endpoint, headers=self._headers)
 
         request.raise_for_status()
 


### PR DESCRIPTION
- Enhance the provider documentation about deduplication_id and how to retrieve session created on the console
- Remove a useless json dump on the job results
- Use termination instead of deletion of ended session (can still be deleted)