### PR TITLE
Pcvl 686 explicit cast to integer

### DIFF
--- a/perceval/algorithm/abstract_algorithm.py
+++ b/perceval/algorithm/abstract_algorithm.py
@@ -44,7 +44,7 @@ class AAlgorithm:
         if not self._check_compatibility():
             raise RuntimeError("Processor and algorithm are not compatible")
         self.default_job_name = None
-        self._max_shots = kwargs.get(self._MAX_SHOTS_NAMED_PARAM)
+        self._max_shots = int(kwargs.get(self._MAX_SHOTS_NAMED_PARAM))
 
     def _check_compatibility(self) -> bool:
         # if self._processor.is_remote:

--- a/perceval/algorithm/abstract_algorithm.py
+++ b/perceval/algorithm/abstract_algorithm.py
@@ -44,7 +44,10 @@ class AAlgorithm:
         if not self._check_compatibility():
             raise RuntimeError("Processor and algorithm are not compatible")
         self.default_job_name = None
-        self._max_shots = int(kwargs.get(self._MAX_SHOTS_NAMED_PARAM))
+        try:
+            self._max_shots = int(kwargs.get(self._MAX_SHOTS_NAMED_PARAM))
+        except:
+            self._max_shots = None
 
     def _check_compatibility(self) -> bool:
         # if self._processor.is_remote:

--- a/perceval/algorithm/abstract_algorithm.py
+++ b/perceval/algorithm/abstract_algorithm.py
@@ -34,20 +34,21 @@ class AAlgorithm:
     _MAX_SHOTS_NAMED_PARAM = "max_shots_per_call"
 
     def __init__(self, processor: AProcessor, **kwargs):
-        # max_shots_per_call must be found in **kwargs when the processor is remote.
-        # This condition is forced because the user will consume credits on the cloud and needs to set an upper bound
-        if (processor.is_remote and self._MAX_SHOTS_NAMED_PARAM not in kwargs) or \
-            (kwargs.get(self._MAX_SHOTS_NAMED_PARAM) and kwargs[self._MAX_SHOTS_NAMED_PARAM] < 1):
-            raise RuntimeError(
-                f'Please input a `{self._MAX_SHOTS_NAMED_PARAM}` positive value when using a RemoteProcessor')
         self._processor = processor
         if not self._check_compatibility():
             raise RuntimeError("Processor and algorithm are not compatible")
+
         self.default_job_name = None
-        try:
-            self._max_shots = int(kwargs.get(self._MAX_SHOTS_NAMED_PARAM))
-        except:
-            self._max_shots = None
+
+        self._max_shots = kwargs.get(self._MAX_SHOTS_NAMED_PARAM)
+        if self._max_shots:
+            self._max_shots = int(self._max_shots)
+            if self._max_shots < 1:
+                raise RuntimeError(f'`{self._MAX_SHOTS_NAMED_PARAM}` must be a positive value')
+        # max_shots_per_call must be found in **kwargs when the processor is remote.
+        # This condition is forced because the user will consume credits on the cloud and needs to set an upper bound
+        if processor.is_remote and not self._max_shots:
+            raise RuntimeError(f'Please input a `{self._MAX_SHOTS_NAMED_PARAM}` value when using a RemoteProcessor')
 
     def _check_compatibility(self) -> bool:
         # if self._processor.is_remote:


### PR DESCRIPTION
I didn't reproduce the `Raise` with :
```
def input_type(key: int):
    print("input conversion: {}".format(key))

def return_type(**kwargs) -> int:
    return kwargs.get("key", None)

value = 1e6
input_type(key = value)
print("output conversion: {}".format(return_type(key=value)))
```

Where does the check come from? Protobuf? Somewhere else?

Shouldn't we fix in a more generic way to prevents similar issues?