### PR TITLE
added Session constructors **kwargs for better compatibility

### DIFF
--- a/perceval/providers/quandela/quandela_session.py
+++ b/perceval/providers/quandela/quandela_session.py
@@ -33,7 +33,7 @@ from perceval.runtime.rpc_handler import RPCHandler
 
 
 class Session(ISession):
-    def __init__(self, platform_name: str, token: str, url: str = None, **kwargs):
+    def __init__(self, platform_name: str, token: str, url: str = None):
         self._platform_name = platform_name
         self._token = token
         self._url = url or QUANDELA_CLOUD_URL

--- a/perceval/providers/quandela/quandela_session.py
+++ b/perceval/providers/quandela/quandela_session.py
@@ -33,7 +33,7 @@ from perceval.runtime.rpc_handler import RPCHandler
 
 
 class Session(ISession):
-    def __init__(self, platform_name: str, token: str, url: str = None):
+    def __init__(self, platform_name: str, token: str, url: str = None, **kwargs):
         self._platform_name = platform_name
         self._token = token
         self._url = url or QUANDELA_CLOUD_URL

--- a/perceval/providers/scaleway/scaleway_session.py
+++ b/perceval/providers/scaleway/scaleway_session.py
@@ -63,7 +63,7 @@ class Session(ISession):
         max_idle_duration_s: int = 1200,
         max_duration_s: int = 3600,
         url: str = _ENDPOINT_URL,
-        **kwargs
+        session_id: str = None
     ) -> None:
 
         self._token = token
@@ -76,7 +76,7 @@ class Session(ISession):
         )
         self._max_duration_s = self.__int_duration(max_duration_s, "max_duration_s")
 
-        self._session_id = kwargs.get("session_id", None)
+        self._session_id = session_id
 
         self._headers = {
             "X-Auth-Token": token,

--- a/perceval/providers/scaleway/scaleway_session.py
+++ b/perceval/providers/scaleway/scaleway_session.py
@@ -76,13 +76,15 @@ class Session(ISession):
         )
         self._max_duration_s = self.__int_duration(max_duration_s, "max_duration_s")
 
-        self._session_id = None
+        self._session_id = kwargs.get("session_id", None)
 
         self._headers = {
             "X-Auth-Token": token,
         }
 
         self._rpc_handler = self.__build_rpc_handler()
+        if self._session_id is not None:
+            self._rpc_handler.set_session_id(self._session_id)
 
     def build_remote_processor(self) -> RemoteProcessor:
         return RemoteProcessor(rpc_handler=self._rpc_handler)

--- a/perceval/providers/scaleway/scaleway_session.py
+++ b/perceval/providers/scaleway/scaleway_session.py
@@ -63,6 +63,7 @@ class Session(ISession):
         max_idle_duration_s: int = 1200,
         max_duration_s: int = 3600,
         url: str = _ENDPOINT_URL,
+        **kwargs
     ) -> None:
 
         self._token = token

--- a/perceval/providers/scaleway/scaleway_session.py
+++ b/perceval/providers/scaleway/scaleway_session.py
@@ -39,7 +39,7 @@ _ENDPOINT_SESSION = "/sessions"
 
 class Session(ISession):
     """
-    :param platform: platform on which circuits will be executed
+    :param platform_name: mane of a platform on which circuits will be executed
 
     :param project_id: UUID of the Scaleway Project the session is attached to
 
@@ -56,7 +56,7 @@ class Session(ISession):
 
     def __init__(
         self,
-        platform: str,
+        platform_name: str,
         project_id: str,
         token: str,
         deduplication_id: str = "",
@@ -69,7 +69,7 @@ class Session(ISession):
         self._token = token
         self._project_id = project_id
         self._url = url
-        self._platform = platform
+        self._platform_name = platform_name
         self._deduplication_id = deduplication_id
         self._max_idle_duration_s = self.__int_duration(
             max_idle_duration_s, "max_idle_duration_s"
@@ -137,6 +137,6 @@ class Session(ISession):
         return RPCHandler(
             project_id=self._project_id,
             headers=self._headers,
-            name=self._platform,
+            name=self._platform_name,
             url=self._url,
         )

--- a/perceval/providers/scaleway/scaleway_session.py
+++ b/perceval/providers/scaleway/scaleway_session.py
@@ -39,7 +39,7 @@ _ENDPOINT_SESSION = "/sessions"
 
 class Session(ISession):
     """
-    :param platform_name: mane of a platform on which circuits will be executed
+    :param platform_name: name of a platform on which circuits will be executed
 
     :param project_id: UUID of the Scaleway Project the session is attached to
 


### PR DESCRIPTION
Without **kwargs user gets somewhat locked on required named arguments of a particular provider, that requires a user to take care about handling both _required_ **and** _unexpected_ arguments.

In particular, in PennyLane-Quandela plugin, a Device class takes **kwargs for having a cleaner user interface and a logic that creates backend and then, if provider name exists in kwargs, it instantiates a session with a cloud provider.

Without **kwargs added to ISession either would happen - an interface of the Device would get bigger for taking into account specifics of provider creation or an ISession will fail with "_unexpected argument_" or "_multiple values for the same argument_"

https://github.com/oradomskyi/pennylane-quandela/blob/main/pennylane_quandela/device.py#:~:text=def%20__init__