### PR TITLE
Pcvl 833 use heralds at first step of feed forward

### DIFF
--- a/perceval/components/feed_forward_configurator.py
+++ b/perceval/components/feed_forward_configurator.py
@@ -136,6 +136,8 @@ class FFCircuitProvider(AFFConfigurator):
     def add_configuration(self, state, circuit: ACircuit) -> FFCircuitProvider:
         state = BasicState(state)
         assert state.m == self.m, f"Incorrect number of modes for state {state} (expected {self.m})"
+        assert not isinstance(circuit, AFFConfigurator), \
+            "Can't add directly a Feed-forward configurator to a configurator (use a Processor)"
         if not self._blocked_circuit_size:
             self._max_circuit_size = max(self._max_circuit_size, circuit.m)
         else:

--- a/perceval/components/feed_forward_configurator.py
+++ b/perceval/components/feed_forward_configurator.py
@@ -116,6 +116,8 @@ class FFCircuitProvider(AFFConfigurator):
     """
 
     def __init__(self, m: int, offset: int, default_circuit: ACircuit, name: str = None):
+        assert not isinstance(default_circuit, AFFConfigurator), \
+            "Can't add directly a Feed-forward configurator to a configurator (use a Processor)"
         super().__init__(m, offset, default_circuit, name)
         self._map: dict[BasicState, ACircuit] = {}
 

--- a/perceval/simulators/simulator.py
+++ b/perceval/simulators/simulator.py
@@ -313,7 +313,8 @@ class Simulator(ISimulator):
                 exec_request = progress_callback((idx + 1) / len(decomposed_input), 'probs')
                 if exec_request is not None and 'cancel_requested' in exec_request and exec_request['cancel_requested']:
                     raise RuntimeError("Cancel requested")
-        res.normalize()
+        if len(res):
+            res.normalize()
         return res, physical_perf
 
     def _probs_svd_fast(self, input_dist, p_threshold, progress_callback: Callable = None):
@@ -395,7 +396,8 @@ class Simulator(ISimulator):
         """
         if self._logical_perf > 0 and physical_perf > 0:
             self._logical_perf = 1 - (1 - self._logical_perf) / physical_perf
-        res.normalize()
+        if len(res):
+            res.normalize()
         return res, physical_perf
 
     def _preprocess_svd(self, svd: SVDistribution) -> tuple[SVDistribution, float, bool, bool]:
@@ -594,7 +596,8 @@ class Simulator(ISimulator):
                 if exec_request is not None and 'cancel_requested' in exec_request and exec_request['cancel_requested']:
                     raise RuntimeError("Cancel requested")
         self._logical_perf = intermediary_logical_perf
-        new_svd.normalize()
+        if len(new_svd):
+            new_svd.normalize()
         return {'results': new_svd,
                 'physical_perf': physical_perf,
                 'logical_perf': self._logical_perf}

--- a/perceval/simulators/simulator_interface.py
+++ b/perceval/simulators/simulator_interface.py
@@ -44,10 +44,6 @@ class ISimulator(ABC):
         self._silent = silent
 
     @abstractmethod
-    def do_postprocess(self, doit: bool):
-        pass
-
-    @abstractmethod
     def set_circuit(self, circuit):
         pass
 
@@ -110,9 +106,6 @@ class ASimulatorDecorator(ISimulator, ABC):
             self._postselect = postselect
         if heralds is not None:
             self._heralds = heralds
-
-    def do_postprocess(self, doit: bool):
-        self._simulator.do_postprocess(doit)
 
     @abstractmethod
     def _prepare_input(self, input_state):

--- a/perceval/simulators/stepper.py
+++ b/perceval/simulators/stepper.py
@@ -56,9 +56,6 @@ class Stepper(ISimulator):
         self._C = None
         self._postprocess = True
 
-    def do_postprocess(self, doit: bool):
-        self._postprocess = doit
-
     def _clear_cache(self):
         self._result_dict = defaultdict(lambda: {'_set': set()})
         self._compiled_input = None

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -277,7 +277,7 @@ def test_empty_output(mock_warn):
     p.min_detected_photons_filter(2)
     p.with_input(BasicState([0, 1, 0]))
 
-    with LogChecker(mock_warn, expected_log_number=2):  # Normalize is called twice
+    with LogChecker(mock_warn, expected_log_number=1):  # Normalize is called once
         res = p.probs()["results"]
     assert res == BSDistribution()
 


### PR DESCRIPTION
Breaking change (that was almost necessary): FFCircuitProvider can no longer be fed with AFFConfigurators (we must use a Processor to do so). This ensures that the circuit size of the FFCircuitProvider completely includes the configured circuits of the AFFConfigurator.

Performance checks:
On the feed-forward notebook:
-  using post-processed CNOT: speed multiplied by 1.5
-  using heralded CNOT: speed multiplied by 5
(Note that the notebook is not using mask since it has a StateVector as input, so we will have gains most of the time, and always when using ancillary modes)
