### PR TITLE
Pcvl 860 more clever tensorproduct for noisy state generation

### DIFF
--- a/perceval/components/source.py
+++ b/perceval/components/source.py
@@ -201,11 +201,12 @@ class Source:
         :param prob_threshold: Probability threshold under which the resulting state is filtered out. By default,
             `global_params['min_p']` value is used.
         """
-        dist = SVDistribution()
         prob_threshold = max(prob_threshold, global_params['min_p'])
         get_logger().debug(f"Apply 'Source' noise model to {expected_input}", channel.general)
-        for photon_count in expected_input:
-            dist = SVDistribution.tensor_product(dist, self.probability_distribution(photon_count), prob_threshold)
+
+        distributions = [self.probability_distribution(photon_count) for photon_count in expected_input]
+        dist = SVDistribution.list_tensor_product(distributions, prob_threshold)
+
         dist.normalize()
         if self.simplify_distribution and self.partially_distinguishable:
             dist = anonymize_annotations(dist, annot_tag='_')

--- a/perceval/simulators/simulator.py
+++ b/perceval/simulators/simulator.py
@@ -224,11 +224,9 @@ class Simulator(ISimulator):
                 self.DEBUG_evolve_count += 1
 
     def _merge_probability_dist(self, input_list) -> BSDistribution:
-        results = BSDistribution()
-        for input_state in input_list:
-            results = BSDistribution.tensor_product(results, _to_bsd(self._evolve[input_state]), merge_modes=True)
-            self.DEBUG_merge_count += 1
-        return results
+        distributions = [_to_bsd(self._evolve[input_state]) for input_state in input_list]
+        self.DEBUG_merge_count += len(distributions) - 1
+        return BSDistribution.list_tensor_product(distributions, merge_modes=True)
 
     @dispatch(BasicState)
     def probs(self, input_state: BasicState) -> BSDistribution:
@@ -360,14 +358,10 @@ class Simulator(ISimulator):
         res = BSDistribution()
         for idx, (prob0, bs_data) in enumerate(decomposed_input):
             """First, recombine evolved state vectors given a single input"""
-            probs_in_s = BSDistribution()
-            for in_s in bs_data:
-                probs_in_s = BSDistribution.tensor_product(probs_in_s, cache[in_s],
-                                                           merge_modes=True,
-                                                           prob_threshold=p_threshold / (10 * prob0))
-                if len(probs_in_s) == 0:
-                    break
-                self.DEBUG_merge_count += 1
+            probs_in_s = BSDistribution.list_tensor_product([cache[state] for state in bs_data],
+                                                            merge_modes=True,
+                                                            prob_threshold=p_threshold / (10 * prob0))
+            self.DEBUG_merge_count += len(bs_data) - 1
 
             """
             1st step of computing logical performance:

--- a/perceval/utils/statevector.py
+++ b/perceval/utils/statevector.py
@@ -392,15 +392,15 @@ class BSDistribution(ProbabilityDistribution):
                             prob_threshold: float = 0) -> BSDistribution:
         """
         Efficient tensor product for a list of BasicState Distribution.
-         Can modify the distributions in place if merge_modes is False.
+         Can modify the distributions in place if merge_modes is False by adding empty modes.
          Performs `len(distributions) - 1` tensor products
          """
-        if len(distributions) == 0:
-            return BSDistribution()
-
         if any(len(dist) == 0 for dist in distributions):
             get_logger().warn("Empty distribution in tensor product. Ignoring it", channel.user)
             distributions = [dist for dist in distributions if len(dist) > 0]
+
+        if len(distributions) == 0:
+            return BSDistribution()
 
         if not merge_modes:
             # Expanding the modes before allows performing the products in any order,

--- a/perceval/utils/statevector.py
+++ b/perceval/utils/statevector.py
@@ -249,6 +249,26 @@ class SVDistribution(ProbabilityDistribution):
                 new_dist[sv] += proba1 * proba2
         return new_dist
 
+    @staticmethod
+    def list_tensor_product(distributions: list[SVDistribution], prob_threshold: float = 0):
+        """Efficient tensor product for a list of distributions"""
+        if len(distributions) == 1:
+            return distributions[0]
+        if len(distributions) == 0:
+            return SVDistribution()
+
+        photon_counts = [len(dist) for dist in distributions]
+
+        # Find the index of lowest product with a sliding window and performs the tensor product with these.
+        products = [photon_counts[i] * photon_counts[i + 1] for i in range(len(photon_counts) - 1)]
+        index = min(range(len(products)), key=products.__getitem__)
+
+        dist = SVDistribution.tensor_product(distributions[index], distributions[index + 1], prob_threshold)
+        distributions[index] = dist
+        distributions.pop(index + 1)
+
+        return SVDistribution.list_tensor_product(distributions, prob_threshold)
+
 
 @dispatch(StateVector, annot_tag=str)
 def anonymize_annotations(sv: StateVector, annot_tag: str = "a") -> StateVector:

--- a/perceval/utils/statevector.py
+++ b/perceval/utils/statevector.py
@@ -255,6 +255,10 @@ class SVDistribution(ProbabilityDistribution):
         if len(distributions) == 0:
             return SVDistribution()
 
+        if any(len(dist) == 0 for dist in distributions):
+            get_logger().warn("Empty distribution in tensor product. Ignoring it", channel.user)
+            distributions = [dist for dist in distributions if len(dist) > 0]
+
         while len(distributions) > 1:
             state_counts = [len(dist) for dist in distributions]
 
@@ -395,14 +399,16 @@ class BSDistribution(ProbabilityDistribution):
             return BSDistribution()
 
         if any(len(dist) == 0 for dist in distributions):
-            get_logger().warn("Empty distribution in tensor product. Ignoring it")
+            get_logger().warn("Empty distribution in tensor product. Ignoring it", channel.user)
             distributions = [dist for dist in distributions if len(dist) > 0]
 
         if not merge_modes:
+            # Expanding the modes before allows performing the products in any order,
+            # as the tensor product is commutative if merge_modes is True
             BSDistribution._expand_modes(distributions)
 
         while len(distributions) > 1:
-            state_counts = [len(dist) for dist in distributions]
+            state_counts = [len(dist) for dist in distributions]  # strictly positive integers
 
             # Find the two smallest distributions and merge them
             idx_a = 0

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -28,13 +28,12 @@
 # SOFTWARE.
 
 import pytest
-import numpy as np
 from unittest.mock import patch
 
 import perceval as pcvl
 from perceval import BSDistribution
 from perceval.components import Circuit, Processor, BS, Source, catalog, UnavailableModeException, Port, PortLocation, \
-    PS, PERM, Detector
+    PERM, Detector
 from perceval.utils import BasicState, StateVector, SVDistribution, Encoding, NoiseModel
 from perceval.backends import Clifford2017Backend
 
@@ -277,7 +276,7 @@ def test_empty_output(mock_warn):
     p.min_detected_photons_filter(2)
     p.with_input(BasicState([0, 1, 0]))
 
-    with LogChecker(mock_warn, expected_log_number=1):  # Normalize is called once
+    with LogChecker(mock_warn, expected_log_number=2):  # Normalize is called once, a void tensor product is called once
         res = p.probs()["results"]
     assert res == BSDistribution()
 

--- a/tests/test_tensorproduct.py
+++ b/tests/test_tensorproduct.py
@@ -28,7 +28,7 @@
 # SOFTWARE.
 
 import pytest
-from perceval import BasicState, StateVector, tensorproduct, BSDistribution
+from perceval import BasicState, StateVector, tensorproduct, BSDistribution, SVDistribution
 from unittest.mock import patch
 from perceval.utils.logging import ExqaliburLogger
 from _test_utils import LogChecker
@@ -121,6 +121,31 @@ def test_bsd_tensor_product(mock_warn):
     # Now with empty BSD
     bsd_list = [bsd_1, bsd_2, BSDistribution(), bsd_3]
 
-    with LogChecker(mock_warn, expected_log_number=1):
+    with LogChecker(mock_warn):
         assert BSDistribution.list_tensor_product(bsd_list, merge_modes=True) == pytest.approx(product), \
             "Wrong list tensor product result when merge_modes is True and there are empty BSD"
+
+
+@patch.object(ExqaliburLogger, "warn")
+def test_svd_tensor_product(mock_warn):
+    svd_1 = SVDistribution({StateVector([2, 3]): .4,
+                            StateVector([0, 1]): .6})
+
+    svd_2 = SVDistribution({StateVector([4, 5]): .3,
+                            StateVector([6, 7]): .7})
+
+    svd_3 = SVDistribution({StateVector([8, 9]): .3,
+                            StateVector([10, 11]): .5,
+                            StateVector([12, 13]): .2})
+
+    assert SVDistribution.tensor_product(svd_1, svd_2) == pytest.approx(svd_1 * svd_2), "SVD tensor product is wrong"
+
+    assert SVDistribution.list_tensor_product([svd_1, svd_2, svd_3]) == pytest.approx(svd_1 * svd_2 * svd_3), \
+        "SVD list tensor product is wrong"
+
+    # Now with empty BSD
+    bsd_list = [svd_1, svd_2, BSDistribution(), svd_3]
+
+    with LogChecker(mock_warn):
+        assert BSDistribution.list_tensor_product(bsd_list) == pytest.approx(svd_1 * svd_2 * svd_3), \
+            "Wrong list tensor product result when there are empty BSD"

--- a/tests/test_tensorproduct.py
+++ b/tests/test_tensorproduct.py
@@ -28,7 +28,10 @@
 # SOFTWARE.
 
 import pytest
-from perceval import BasicState, StateVector, tensorproduct
+from perceval import BasicState, StateVector, tensorproduct, BSDistribution
+from unittest.mock import patch
+from perceval.utils.logging import ExqaliburLogger
+from _test_utils import LogChecker
 
 sv0 = StateVector([0, 1]) + StateVector([1, 1]) * 1j
 sv1 = StateVector([2, 3]) + StateVector([4, 5])
@@ -79,3 +82,45 @@ def test_power():
     result = bs ** power
     expected = BasicState([6, 7] * power)
     assert result == expected, "BS pow is wrong"
+
+
+@patch.object(ExqaliburLogger, "warn")
+def test_bsd_tensor_product(mock_warn):
+    bsd_1 = BSDistribution({BasicState([2, 3]): .4,
+                            BasicState([0, 1]): .6})
+
+    bsd_2 = BSDistribution({BasicState([4, 5]): .3,
+                            BasicState([6, 7]): .7})
+
+    bsd_3 = BSDistribution({BasicState([8, 9]): .3,
+                            BasicState([10, 11]): .5,
+                            BasicState([12, 13]): .2})
+
+    assert BSDistribution.tensor_product(bsd_1, bsd_2) == pytest.approx(bsd_1 * bsd_2), "BSD tensor product is wrong"
+
+    assert BSDistribution.tensor_product(bsd_1, bsd_2, merge_modes=True) == pytest.approx(BSDistribution({
+        BasicState([6, 8]): .4 * .3 + .6 * .7,
+        BasicState([8, 10]): .4 * .7,
+        BasicState([4, 6]): .6 * .3,
+    })), "Wrong tensor product result when merge_modes is True"
+
+    assert (BSDistribution.tensor_product(bsd_1, bsd_2, merge_modes=True)
+            == pytest.approx(BSDistribution.tensor_product(bsd_2, bsd_1, merge_modes=True))), \
+        "BSD tensor product is not symmetric when merge_modes is True"
+
+    assert BSDistribution.list_tensor_product([bsd_1, bsd_2, bsd_3]) == pytest.approx(bsd_1 * bsd_2 * bsd_3), \
+        "BSD list tensor product is wrong"
+
+    product = BSDistribution()
+    for bsd in [bsd_1, bsd_2, bsd_3]:
+        product = BSDistribution.tensor_product(product, bsd, merge_modes=True)
+
+    assert BSDistribution.list_tensor_product([bsd_1, bsd_2, bsd_3], merge_modes=True) == pytest.approx(product), \
+        "Wrong list tensor product result when merge_modes is True"
+
+    # Now with empty BSD
+    bsd_list = [bsd_1, bsd_2, BSDistribution(), bsd_3]
+
+    with LogChecker(mock_warn, expected_log_number=1):
+        assert BSDistribution.list_tensor_product(bsd_list, merge_modes=True) == pytest.approx(product), \
+            "Wrong list tensor product result when merge_modes is True and there are empty BSD"

--- a/tests/test_tensorproduct.py
+++ b/tests/test_tensorproduct.py
@@ -143,8 +143,8 @@ def test_svd_tensor_product(mock_warn):
     assert SVDistribution.list_tensor_product([svd_1, svd_2, svd_3]) == pytest.approx(svd_1 * svd_2 * svd_3), \
         "SVD list tensor product is wrong"
 
-    # Now with empty BSD
-    bsd_list = [svd_1, svd_2, BSDistribution(), svd_3]
+    # Now with empty SVD
+    bsd_list = [svd_1, svd_2, SVDistribution(), svd_3]
 
     with LogChecker(mock_warn):
         assert SVDistribution.list_tensor_product(bsd_list) == pytest.approx(svd_1 * svd_2 * svd_3), \

--- a/tests/test_tensorproduct.py
+++ b/tests/test_tensorproduct.py
@@ -147,5 +147,5 @@ def test_svd_tensor_product(mock_warn):
     bsd_list = [svd_1, svd_2, BSDistribution(), svd_3]
 
     with LogChecker(mock_warn):
-        assert BSDistribution.list_tensor_product(bsd_list) == pytest.approx(svd_1 * svd_2 * svd_3), \
+        assert SVDistribution.list_tensor_product(bsd_list) == pytest.approx(svd_1 * svd_2 * svd_3), \
             "Wrong list tensor product result when there are empty BSD"


### PR DESCRIPTION
Some benchmarks on my laptop, with a fully imperfect source, for the function `Processor.with_input`:

To generate a state with 9 photons [1, 1, ...]
Before this PR: 50 seconds
After this PR: 40 seconds

To generate a state with 9 photons in 18 modes [1, 0, 1, 0, ...]
Before this PR: 110 seconds
After this PR: 40 seconds  (the time is now almost independant of empty modes)

To generate a state with 9 photons in the same mode [9]
Before this PR: 160 seconds
After this PR: 38 seconds

The modifications of the tensor product method were also done in the Simulator. Again, the benchmark uses a fully imperfect source, but is now for the function `Processor.probs`, using SLOS.

Using a random unitary, with 7 modes and photons [1, 1... ], no photons filter
Before this PR: 32 seconds
After this PR: 30 seconds
Globally, 6 to 8% speedup using different numbers of photons and modes

Using an empty circuit
Before this PR: 7.9 seconds
After this PR: 8 seconds
Globally, 1 to 2% slowdown

[benchmark_sources.txt](https://github.com/user-attachments/files/18329910/benchmark_sources.txt)
[benchmark sources + probs.txt](https://github.com/user-attachments/files/18329911/benchmark.sources.%2B.probs.txt)