### PR TITLE
PCVL-964 add build_experiment() to CatalogItem's interface

### DIFF
--- a/perceval/components/component_catalog.py
+++ b/perceval/components/component_catalog.py
@@ -30,7 +30,7 @@ import importlib
 from abc import ABC, abstractmethod
 
 from perceval.utils import Parameter
-from perceval.components import Processor, Circuit
+from perceval.components import Processor, Circuit, Experiment
 from perceval.utils.logging import get_logger, channel
 
 
@@ -81,7 +81,7 @@ class CatalogItem(ABC):
         return value
 
     def _init_processor(self, **kwargs):
-        return Processor(kwargs.get("backend", self._default_backend), self.build_circuit(**kwargs),
+        return Processor(kwargs.get("backend", self._default_backend), self.build_experiment(**kwargs),
                          name=kwargs.get("name") or self._name.upper())
 
     @abstractmethod
@@ -89,6 +89,14 @@ class CatalogItem(ABC):
         """Build the component as circuit
 
         :return: A Perceval circuit
+        """
+        pass
+
+    @abstractmethod
+    def build_experiment(self, **kwargs) -> Experiment:
+        """Build the component as experiment
+
+        :return: A Perceval experiment
         """
         pass
 

--- a/perceval/components/core_catalog/controlled_rotation_gates.py
+++ b/perceval/components/core_catalog/controlled_rotation_gates.py
@@ -34,7 +34,7 @@ import numpy as np
 import cmath as cm
 from scipy.linalg import block_diag
 
-from perceval.components import Circuit, Port, Unitary
+from perceval.components import Circuit, Port, Unitary, Processor, Experiment
 from perceval.components.component_catalog import CatalogItem
 from perceval.utils import Encoding, PostSelect, Matrix
 
@@ -93,7 +93,7 @@ ctrlN (dual rail)  ─────┤     ├───── ctrlN (dual rail)
     def __init__(self):
         super().__init__("postprocessed controlled gate")
 
-    def build_circuit(self, **kwargs):
+    def build_circuit(self, **kwargs) -> Circuit:
         """
         kwargs:
             - n : int, number of qubit of the gate.
@@ -116,17 +116,20 @@ ctrlN (dual rail)  ─────┤     ├───── ctrlN (dual rail)
         m = build_control_gate_unitary(n, alpha)
         return Circuit(4*n, name="postprocessed controlled gate").add(0, Unitary(m))
 
-    def build_processor(self, **kwargs):
-        p = self._init_processor(**kwargs)
+    def build_experiment(self, **kwargs) -> Experiment:
+        e = Experiment(self.build_circuit(**kwargs))
         n = kwargs["n"]
 
-        p.set_postselection(PostSelect('&'.join([f"[{2*n},{2*n+1}]==1" for n in range(n)])))
+        e.set_postselection(PostSelect('&'.join([f"[{2*n},{2*n+1}]==1" for n in range(n)])))
 
         for i in range(n - 1):
-            p.add_port(2 * i, Port(Encoding.DUAL_RAIL, f"ctrl{i}"))
-        p.add_port(2 * (n - 1), Port(Encoding.DUAL_RAIL, "data"))
+            e.add_port(2 * i, Port(Encoding.DUAL_RAIL, f"ctrl{i}"))
+        e.add_port(2 * (n - 1), Port(Encoding.DUAL_RAIL, "data"))
 
         for i in range(2 * n, 4 * n):
-            p.add_herald(i, 0)
+            e.add_herald(i, 0)
 
-        return p
+        return e
+
+    def build_processor(self, **kwargs) -> Processor:
+        return self._init_processor(**kwargs)

--- a/perceval/components/core_catalog/gates_1qubit.py
+++ b/perceval/components/core_catalog/gates_1qubit.py
@@ -31,7 +31,7 @@ import math
 from abc import ABC, abstractmethod
 from numbers import Number
 
-from perceval.components import Processor, Circuit, BS, PS, PERM, Port
+from perceval.components import Processor, Circuit, BS, PS, PERM, Port, Experiment
 from perceval.utils import Encoding, P
 from perceval.components.component_catalog import CatalogItem
 
@@ -73,9 +73,12 @@ class ASingleQubitGate(CatalogItem, ABC):
     def str_repr(self):
         return _get_component_str_repr(self.repr_name)
 
+    def build_experiment(self, **kwargs) -> Experiment:
+        e = Experiment(self.build_circuit(**kwargs))
+        return e.add_port(0, Port(Encoding.DUAL_RAIL, 'data'))
+
     def build_processor(self, **kwargs) -> Processor:
-        p = self._init_processor(**kwargs)
-        return p.add_port(0, Port(Encoding.DUAL_RAIL, 'data'))
+        return self._init_processor(**kwargs)
 
 
 class AFixedItem(ASingleQubitGate, ABC):
@@ -158,7 +161,7 @@ class AParamItem(ASingleQubitGate, ABC):
     def get_circuit(self, param) -> Circuit:
         pass
 
-    def build_circuit(self, **kwargs):
+    def build_circuit(self, **kwargs) -> Circuit:
         param = kwargs.get(self.param_key, 0.0)
         param = self._handle_param(param)
         name = self.repr_name

--- a/perceval/components/core_catalog/generic_2mode.py
+++ b/perceval/components/core_catalog/generic_2mode.py
@@ -27,7 +27,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from perceval.components import Circuit, BS
+from perceval.components import Circuit, BS, Processor, Experiment
 from perceval.components.component_catalog import CatalogItem
 
 
@@ -49,12 +49,15 @@ class Generic2ModeItem(CatalogItem):
     def __init__(self):
         super().__init__("generic 2 mode circuit")
 
-    def build_circuit(self, **kwargs):
+    def build_circuit(self, **kwargs) -> Circuit:
         return Circuit(2, name=kwargs.get("name", "U2")) \
             // BS.H(theta=self._handle_param(kwargs.get("theta", "theta")),
                     phi_tl=self._handle_param(kwargs.get("phi_tl", "phi_tl")),
                     phi_bl=self._handle_param(kwargs.get("phi_bl", "phi_bl")),
                     phi_tr=self._handle_param(kwargs.get("phi_tr", "phi_tr")))
 
-    def build_processor(self, **kwargs):
+    def build_experiment(self, **kwargs) -> Experiment:
+        return Experiment(self.build_circuit(**kwargs))
+
+    def build_processor(self, **kwargs) -> Processor:
         return self._init_processor(**kwargs)

--- a/perceval/components/core_catalog/heralded_cnot.py
+++ b/perceval/components/core_catalog/heralded_cnot.py
@@ -30,6 +30,8 @@
 from perceval.components import Circuit, BS, Port
 from perceval.components.component_catalog import CatalogItem
 from perceval.components.core_catalog.heralded_cz import HeraldedCzItem
+from perceval.components.experiment import Experiment
+from perceval.components.processor import Processor
 from perceval.utils import Encoding
 
 
@@ -48,7 +50,7 @@ data (dual rail) ─────┤ H ├───┤          ├───┤ H
     def __init__(self):
         super().__init__("heralded cnot")
 
-    def build_circuit(self, **kwargs):
+    def build_circuit(self, **kwargs) -> Circuit:
         c = Circuit(6, name="Heralded CNOT")
         c.add(2, BS.H())
         heralded_cz = HeraldedCzItem()
@@ -56,9 +58,12 @@ data (dual rail) ─────┤ H ├───┤          ├───┤ H
         c.add(2, BS.H())
         return c
 
-    def build_processor(self, **kwargs):
-        p = self._init_processor(**kwargs)
-        return p.add_port(0, Port(Encoding.DUAL_RAIL, 'ctrl'))\
+    def build_experiment(self, **kwargs) -> Experiment:
+        e = Experiment(self.build_circuit(**kwargs))
+        return e.add_port(0, Port(Encoding.DUAL_RAIL, 'ctrl'))\
             .add_port(2, Port(Encoding.DUAL_RAIL, 'data'))\
             .add_herald(4, 1)\
             .add_herald(5, 1)
+
+    def build_processor(self, **kwargs) -> Processor:
+        return self._init_processor(**kwargs)

--- a/perceval/components/core_catalog/heralded_cz.py
+++ b/perceval/components/core_catalog/heralded_cz.py
@@ -29,7 +29,7 @@
 
 import math
 
-from perceval.components import Processor, Circuit, PERM, BS, PS, Barrier
+from perceval.components import Processor, Circuit, PERM, BS, PS, Barrier, Experiment
 from perceval.components.component_catalog import CatalogItem
 from perceval.components.port import Port, Encoding
 
@@ -71,9 +71,12 @@ data (dual rail) ─────┤     ├───── data (dual rail)
                 .add(2, last_modes_cz, merge=True)
                 .add(1, PERM([1, 0])))
 
-    def build_processor(self, **kwargs) -> Processor:
-        p = self._init_processor(**kwargs)
-        return p.add_port(0, Port(Encoding.DUAL_RAIL, 'ctrl')) \
+    def build_experiment(self, **kwargs) -> Experiment:
+        e = Experiment(self.build_circuit(**kwargs))
+        return e.add_port(0, Port(Encoding.DUAL_RAIL, 'ctrl')) \
             .add_port(2, Port(Encoding.DUAL_RAIL, 'data')) \
             .add_herald(4, 1) \
             .add_herald(5, 1)
+
+    def build_processor(self, **kwargs) -> Processor:
+        return self._init_processor(**kwargs)

--- a/perceval/components/core_catalog/klm_cnot.py
+++ b/perceval/components/core_catalog/klm_cnot.py
@@ -29,7 +29,7 @@
 
 from math import sqrt
 
-from perceval.components import Circuit, BS, PERM, Port
+from perceval.components import Circuit, BS, PERM, Port, Processor, Experiment
 from perceval.components.component_catalog import CatalogItem
 from perceval.utils import Encoding
 
@@ -58,7 +58,7 @@ data (dual rail) ─────┤     ├───── data (dual rail)
     def __init__(self):
         super().__init__("klm cnot")
 
-    def build_circuit(self, **kwargs):
+    def build_circuit(self, **kwargs) -> Circuit:
         return (Circuit(8, name=_GATE_NAME)
                 .add(1, PERM([2, 4, 3, 0, 1]))
                 .add(4, BS.H())
@@ -77,11 +77,14 @@ data (dual rail) ─────┤     ├───── data (dual rail)
                 .add(4, BS.H())
                 .add(1, PERM([4, 3, 0, 2, 1])))
 
-    def build_processor(self, **kwargs):
-        p = self._init_processor(**kwargs)
-        return p.add_port(0, Port(Encoding.DUAL_RAIL, 'ctrl')) \
+    def build_experiment(self, **kwargs) -> Experiment:
+        e = Experiment(self.build_circuit(**kwargs))
+        return e.add_port(0, Port(Encoding.DUAL_RAIL, 'ctrl')) \
             .add_port(2, Port(Encoding.DUAL_RAIL, 'data')) \
             .add_herald(4, 0) \
             .add_herald(5, 1) \
             .add_herald(6, 0) \
             .add_herald(7, 1)
+
+    def build_processor(self, **kwargs) -> Processor:
+        return self._init_processor(**kwargs)

--- a/perceval/components/core_catalog/mzi.py
+++ b/perceval/components/core_catalog/mzi.py
@@ -31,7 +31,7 @@ import math
 from abc import ABC
 
 
-from perceval.components import Processor, Circuit, BS, PS
+from perceval.components import Processor, Circuit, BS, PS, Experiment
 from perceval.components.component_catalog import CatalogItem
 
 
@@ -53,6 +53,9 @@ class AMZI(CatalogItem, ABC):
             CatalogItem._handle_param(kwargs.get("phi_b", "phi_b")), \
             CatalogItem._handle_param(kwargs.get("theta_a", math.pi/2)), \
             CatalogItem._handle_param(kwargs.get("theta_b", math.pi/2))
+
+    def build_experiment(self, **kwargs) -> Experiment:
+        return Experiment(self.build_circuit(**kwargs))
 
     def build_processor(self, **kwargs) -> Processor:
         return self._init_processor(**kwargs)

--- a/perceval/components/core_catalog/postprocessed_ccz.py
+++ b/perceval/components/core_catalog/postprocessed_ccz.py
@@ -29,7 +29,7 @@
 
 from math import pi
 
-from perceval.components import Circuit, Port, Unitary
+from perceval.components import Circuit, Port, Unitary, Processor, Experiment
 from perceval.components.component_catalog import CatalogItem
 from perceval.components.core_catalog import controlled_rotation_gates
 from perceval.utils import Encoding, PostSelect, Matrix
@@ -52,14 +52,14 @@ data (dual rail)  ─────┤     ├───── data (dual rail)
     def __init__(self):
         super().__init__("postprocessed ccz")
 
-    def build_circuit(self, **kwargs):
+    def build_circuit(self, **kwargs) -> Circuit:
         m = Matrix(controlled_rotation_gates.build_control_gate_unitary(3, pi))
         return Circuit(12, name="PostProcessed CCZ").add(0, Unitary(m))
 
-    def build_processor(self, **kwargs):
-        p = self._init_processor(**kwargs)
-        p.set_postselection(PostSelect("[0,1]==1 & [2,3]==1 & [4,5]==1"))
-        return p.add_port(0, Port(Encoding.DUAL_RAIL, 'ctrl0')) \
+    def build_experiment(self, **kwargs) -> Experiment:
+        e = Experiment(self.build_circuit(**kwargs))
+        e.set_postselection(PostSelect("[0,1]==1 & [2,3]==1 & [4,5]==1"))
+        return e.add_port(0, Port(Encoding.DUAL_RAIL, 'ctrl0')) \
             .add_port(2, Port(Encoding.DUAL_RAIL, 'ctrl1')) \
             .add_port(4, Port(Encoding.DUAL_RAIL, 'data')) \
             .add_herald(6, 0) \
@@ -68,3 +68,6 @@ data (dual rail)  ─────┤     ├───── data (dual rail)
             .add_herald(9, 0) \
             .add_herald(10, 0) \
             .add_herald(11, 0)
+
+    def build_processor(self, **kwargs)-> Processor:
+        return self._init_processor(**kwargs)

--- a/perceval/components/core_catalog/postprocessed_cnot.py
+++ b/perceval/components/core_catalog/postprocessed_cnot.py
@@ -29,7 +29,7 @@
 
 from .postprocessed_cz import PostProcessedCzItem
 
-from perceval.components import Circuit, BS, Port
+from perceval.components import Circuit, BS, Port, Processor, Experiment
 from perceval.components.component_catalog import CatalogItem
 from perceval.utils import Encoding, PostSelect
 
@@ -49,17 +49,20 @@ data (dual rail) ─────┤     ├───── data (dual rail)
     def __init__(self):
         super().__init__("postprocessed cnot")
 
-    def build_circuit(self, **kwargs):
+    def build_circuit(self, **kwargs) -> Circuit:
         postprocessed_cz = PostProcessedCzItem()
         return (Circuit(6, name="PostProcessed CNOT")
                 .add((2, 3), BS.H())
                 .add(0, postprocessed_cz.build_circuit(), merge=True)
                 .add((2, 3), BS.H()))
 
-    def build_processor(self, **kwargs):
-        p = self._init_processor(**kwargs)
-        p.set_postselection(PostSelect("[0,1]==1 & [2,3]==1"))
-        return p.add_port(0, Port(Encoding.DUAL_RAIL, 'ctrl')) \
+    def build_experiment(self, **kwargs) -> Experiment:
+        e = Experiment(self.build_circuit(**kwargs))
+        e.set_postselection(PostSelect("[0,1]==1 & [2,3]==1"))
+        return e.add_port(0, Port(Encoding.DUAL_RAIL, 'ctrl')) \
             .add_port(2, Port(Encoding.DUAL_RAIL, 'data')) \
             .add_herald(4, 0) \
             .add_herald(5, 0)
+
+    def build_processor(self, **kwargs) -> Processor:
+        return self._init_processor(**kwargs)

--- a/perceval/components/core_catalog/postprocessed_cz.py
+++ b/perceval/components/core_catalog/postprocessed_cz.py
@@ -27,7 +27,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from perceval.components import Circuit, PERM, BS, Port, Barrier
+from perceval.components import Circuit, PERM, BS, Port, Barrier, Processor, Experiment
 from perceval.components.component_catalog import CatalogItem
 from perceval.utils import Encoding, PostSelect
 
@@ -47,7 +47,7 @@ data (dual rail) ─────┤     ├───── data (dual rail)
     def __init__(self):
         super().__init__("postprocessed cz")
 
-    def build_circuit(self, **kwargs):
+    def build_circuit(self, **kwargs) -> Circuit:
         theta_13 = BS.r_to_theta(1 / 3)
         return (Circuit(6, name="PostProcessed CZ")
                 .add(1, PERM([2, 1, 3, 0]))  # So that both heralded modes are on the bottom of the gate
@@ -57,10 +57,13 @@ data (dual rail) ─────┤     ├───── data (dual rail)
                 .add((4, 5), BS.H(theta_13))
                 .add(1, PERM([3, 1, 0, 2])))  # So that both heralded modes are on the bottom of the gate
 
-    def build_processor(self, **kwargs):
-        p = self._init_processor(**kwargs)
-        p.set_postselection(PostSelect("[0,1]==1 & [2,3]==1"))
-        return p.add_port(0, Port(Encoding.DUAL_RAIL, 'ctrl')) \
+    def build_experiment(self, **kwargs) -> Experiment:
+        e = Experiment(self.build_circuit(**kwargs))
+        e.set_postselection(PostSelect("[0,1]==1 & [2,3]==1"))
+        return e.add_port(0, Port(Encoding.DUAL_RAIL, 'ctrl')) \
             .add_port(2, Port(Encoding.DUAL_RAIL, 'data')) \
             .add_herald(4, 0) \
             .add_herald(5, 0)
+
+    def build_processor(self, **kwargs) -> Processor:
+        return self._init_processor(**kwargs)

--- a/perceval/components/core_catalog/toffoli.py
+++ b/perceval/components/core_catalog/toffoli.py
@@ -26,7 +26,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from perceval.components import Circuit, Port, BS
+from perceval.components import Circuit, Port, BS, Processor, Experiment
 from perceval.components.component_catalog import CatalogItem
 from perceval.components.core_catalog.postprocessed_ccz import PostProcessedCCZItem
 from perceval.utils import Encoding, PostSelect
@@ -47,17 +47,17 @@ data (dual rail)  ─────┤ H ├───┤          ├───┤ 
     def __init__(self):
         super().__init__("toffoli")
 
-    def build_circuit(self, **kwargs):
+    def build_circuit(self, **kwargs) -> Circuit:
         c = Circuit(12, name="Toffoli")
         c.add(4, BS.H())
         c.add(0, PostProcessedCCZItem().build_circuit(), merge=True)
         c.add(4, BS.H())
         return c
 
-    def build_processor(self, **kwargs):
-        p = self._init_processor(**kwargs)
-        p.set_postselection(PostSelect("[0,1]==1 & [2,3]==1 & [4,5]==1"))
-        return p.add_port(0, Port(Encoding.DUAL_RAIL, 'ctrl0')) \
+    def build_experiment(self, **kwargs) -> Experiment:
+        e = Experiment(self.build_circuit(**kwargs))
+        e.set_postselection(PostSelect("[0,1]==1 & [2,3]==1 & [4,5]==1"))
+        return e.add_port(0, Port(Encoding.DUAL_RAIL, 'ctrl0')) \
             .add_port(2, Port(Encoding.DUAL_RAIL, 'ctrl1')) \
             .add_port(4, Port(Encoding.DUAL_RAIL, 'data')) \
             .add_herald(6, 0) \
@@ -66,3 +66,6 @@ data (dual rail)  ─────┤ H ├───┤          ├───┤ 
             .add_herald(9, 0) \
             .add_herald(10, 0) \
             .add_herald(11, 0)
+
+    def build_processor(self, **kwargs) -> Processor:
+        return self._init_processor(**kwargs)


### PR DESCRIPTION
I kept the `build_processor()` in `CatalogItem`'s interface, but its implementation is always a simple `_init_processor()` call.
Should `build_processor()` stop being an abstract method?