### PR TITLE
Allow numpy arrays to be used directly in Unitary.

### DIFF
--- a/perceval/components/unitary_components.py
+++ b/perceval/components/unitary_components.py
@@ -432,7 +432,7 @@ class Unitary(ACircuit):
     def __init__(self, U: Matrix | np.ndarray, name: str = None, use_polarization: bool = False):
         assert U is not None, "A unitary matrix is required"
 
-        if isinstance(U, np.ndarray):
+        if not isinstance(U, Matrix):
             U = Matrix(U)
 
         assert U.is_unitary(), "U parameter must be a unitary matrix"

--- a/perceval/components/unitary_components.py
+++ b/perceval/components/unitary_components.py
@@ -429,8 +429,12 @@ class Unitary(ACircuit):
     """
     DEFAULT_NAME = "Unitary"
 
-    def __init__(self, U: Matrix, name: str = None, use_polarization: bool = False):
+    def __init__(self, U: Matrix | np.ndarray, name: str = None, use_polarization: bool = False):
         assert U is not None, "A unitary matrix is required"
+
+        if isinstance(U, np.ndarray):
+            U = Matrix(U)
+
         assert U.is_unitary(), "U parameter must be a unitary matrix"
         # A symbolic matrix is not a use case for this component
         assert not U.is_symbolic(), "U parameter must not be symbolic"


### PR DESCRIPTION
Custom `Unitary` objects are very often defined from `numpy` arrays. However, trying to directly use a `numpy` array raises an error, as you have to first convert from `numpy` to `Matrix`, before passing through `Unitary`.

```python
unitary = Unitary(Matrix(numpy_matrix))
```

For conciseness, I have updated the `Unitary` class to  accept `numpy` arrays. When using `numpy`, the user input is automatically converted to `Matrix` type.
```python
unitary = Unitary(numpy_matrix)
```