### PR TITLE
Allow input states to be defined as lists/tuples

### DIFF
--- a/perceval/components/experiment.py
+++ b/perceval/components/experiment.py
@@ -36,7 +36,7 @@ from typing import Callable
 from multipledispatch import dispatch
 
 from perceval.utils import FockState, AnnotatedFockState, Parameter, PostSelect, LogicalState, NoiseModel, ModeType, StateVector, \
-    SVDistribution, NoisyFockState
+    SVDistribution, NoisyFockState, BasicState
 from perceval.utils.logging import get_logger, channel
 from perceval.utils.algorithms.simplification import perm_compose, simplify
 from ._mode_connector import ModeConnector, UnavailableModeException
@@ -822,6 +822,14 @@ class Experiment:
 
         self._input_state = FockState(input_list)
         self._input_changed()
+
+    @dispatch((list, tuple))
+    def with_input(self, input_state: list | tuple):
+        assert not any((self._in_ports, self._out_ports)), (
+            f"Input state of type `{type(input_state).__name__}` on an experiment "
+            "with ports is ambiguous. Please use input of type `LogicalState`."
+        )
+        self.with_input(BasicState(input_state))
 
     @dispatch(AnnotatedFockState)
     def with_input(self, input_state: AnnotatedFockState) -> None:


### PR DESCRIPTION
The large majority of the time, users define input states as lists when defining Experiments. However, the list/tuple must first be passed to a `BasicState` before passing into `Experiment.with_input`. e.g.

```python
experiment.with_input(BasicState([1, 2, 0, 1, 2]))
```

For conciseness, and to lower the need for excess object instantiation on the user's part, I have introduced a new overloaded method for `Experiment.with_input` that accepts lists & tuples.

```python
experiment.with_input([1, 2, 0, 1, 2])
```


To avoid possible confusion between logical states and Fock states, list/tuple type inputs cannot work with processors which have been encoded with ports. Such an instance will raise an `AssertionError`.

```
AssertionError: Input state of type `tuple` on an experiment with ports is ambiguous. Please use input of type `LogicalState`.
```