### PR TITLE
Add Kipu Quantum Hub provider (perceval.providers.kipu)

### DIFF
--- a/.github/workflows/autotests.yml
+++ b/.github/workflows/autotests.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install .
+        python -m pip install .[kipu]
         python -m pip install -r tests/requirements.txt
 
     - name: Lint with flake8
@@ -106,7 +106,6 @@ jobs:
         python -m pip install .
         python -m pip install -r tests/requirements.txt
         python -m pip uninstall -y -r .github/rendering_requirements.txt
-        python -m pip uninstall -y qhub-api
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/autotests.yml
+++ b/.github/workflows/autotests.yml
@@ -106,6 +106,7 @@ jobs:
         python -m pip install .
         python -m pip install -r tests/requirements.txt
         python -m pip uninstall -y -r .github/rendering_requirements.txt
+        python -m pip uninstall -y qhub-api
 
     - name: Test with pytest
       run: |

--- a/docs/source/reference/providers.rst
+++ b/docs/source/reference/providers.rst
@@ -100,3 +100,92 @@ Then, we can attach a toy circuit and send it on our session
 >>> print(job)
 
 Congratulation you can now design and send jobs to Scaleway QaaS through your processor. You can continue with the documentation of :ref:`algorithm`.
+
+Kipu Quantum Hub
+----------------
+
+The `Kipu Quantum Hub <https://dashboard.hub.kipu-quantum.com/>`_ brokers quantum jobs to multiple quantum providers. Through it, Perceval can run Quandela photonic backends hosted on the Hub.
+
+This provider relies on an optional dependency (the ``qhub-api`` package). Install it with::
+
+    pip install perceval[kipu]
+
+If the dependency is missing, creating a Kipu ``RemoteProcessor`` raises an ``ImportError`` telling you to run the command above.
+
+Kipu authentication
+^^^^^^^^^^^^^^^^^^^
+
+To use the Kipu Quantum Hub as a provider you need a Kipu Quantum account and a Personal Access Token (PAT).
+
+1. Create a Kipu Quantum account at the `Kipu Quantum Hub dashboard <https://dashboard.hub.kipu-quantum.com/>`_.
+2. Copy your Personal Access Token (PAT) from the dashboard.
+3. (Optional) Provide an ``organization_id`` to run within an organization context. If omitted, your `personal account <https://docs.hub.kipu-quantum.com/manage-organizations#switch-context-between-personal-account-and-organization>`_ is used.
+
+Alternatively, authenticate with the `qhubctl <https://docs.hub.kipu-quantum.com/quickstart>`_ CLI instead of passing a token:
+
+.. code-block:: bash
+
+    qhubctl login
+
+Once logged in, create the session **without** a ``token`` — it is resolved automatically from the environment or the ``qhubctl`` credentials file.
+
+KipuSession
+^^^^^^^^^^^
+
+.. autoclass:: perceval.providers.kipu.Session
+   :members:
+
+Available platforms
+^^^^^^^^^^^^^^^^^^^
+
+The ``platform_name`` is a Hub backend id, or one of its aliases:
+
+============================  =============
+Backend id                    Alias
+============================  =============
+``quandela.sim.belenos``       ``sim:belenos``
+``quandela.qpu.belenos``      ``qpu:belenos``
+============================  =============
+
+Create a Kipu session
+^^^^^^^^^^^^^^^^^^^^^
+
+Import the library and the Kipu Quantum Hub provider:
+
+>>> import perceval as pcvl
+>>> import perceval.providers.kipu as kipu
+
+Provide your Personal Access Token (PAT) and choose a platform:
+
+>>> TOKEN = "your-personal-access-token"
+>>> PLATFORM_NAME = "quandela.sim.belenos"
+
+Create the session (``organization_id`` is optional):
+
+>>> session = kipu.Session(platform_name=PLATFORM_NAME, token=TOKEN)
+
+If you authenticated via ``qhubctl login``, omit the token:
+
+>>> session = kipu.Session(platform_name=PLATFORM_NAME)
+
+.. note:: The Kipu session is stateless: there is no ``start``/``stop`` to call and no ``with`` block lifecycle to manage, unlike the Scaleway session.
+
+.. note:: ``JobGroup`` (batch job submission) is not supported by the Kipu Quantum Hub provider, like the Scaleway provider.
+
+Send a circuit to a Kipu-hosted backend
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Build a :code:`RemoteProcessor` from the session:
+
+>>> processor = session.build_remote_processor()
+
+Attach a toy circuit and send it:
+
+>>> processor.set_circuit(pcvl.Circuit(m=2, name="a-toy-circuit") // pcvl.BS.H())
+>>> processor.with_input(pcvl.BasicState("|0,1>"))
+>>> processor.min_detected_photons_filter(1)
+>>> sampler = pcvl.algorithm.Sampler(processor, max_shots_per_call=10_000)
+>>> job = sampler.samples(100)
+>>> print(job)
+
+You can now design and send jobs to Quandela backends through the Kipu Quantum Hub. Continue with the documentation of :ref:`algorithm`.

--- a/perceval/providers/kipu/__init__.py
+++ b/perceval/providers/kipu/__init__.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022 Quandela
+# Copyright (c) 2026 Kipu Quantum GmbH
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,30 +26,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""Provider related imports and classes"""
 
-from perceval.runtime import ISession
+from .kipu_session import Session
+from .kipu_rpc_handler import KipuRPCHandler
 
-from .quandela import Session as QuandelaSession
-from .scaleway import Session as ScalewaySession
-from .kipu import Session as KipuSession
-
-PROVIDER_LIST = {
-    "Quandela": QuandelaSession,
-    "Scaleway": ScalewaySession,
-    "Kipu": KipuSession,
-}
-
-
-class ProviderFactory:
-    @staticmethod
-    def get_provider(provider_name: str, **kwargs) -> ISession:
-        name = provider_name
-        if name in PROVIDER_LIST:
-            return PROVIDER_LIST[name](**kwargs)
-
-        raise KeyError(f'Cloud Provider "{name}" not found, available providers are: {ProviderFactory.list()}.')
-
-    @staticmethod
-    def list():
-        return list(PROVIDER_LIST.keys())
+__all__ = ["Session", "KipuRPCHandler"]

--- a/perceval/providers/kipu/kipu_rpc_handler.py
+++ b/perceval/providers/kipu/kipu_rpc_handler.py
@@ -29,18 +29,19 @@
 
 from datetime import datetime
 
-from perceval.utils.logging import get_logger, channel
-
 _MISSING_QHUB_MSG = (
     "The Kipu Quantum Hub provider requires the 'qhub-api' package. "
     "Install it with: pip install perceval[kipu]"
 )
 
-_SUPPORTED_BACKENDS = ("quandela.sim.belenos", "quandela.qpu.belenos")
+_SIM_BELENOS = "quandela.sim.belenos"
+_QPU_BELENOS = "quandela.qpu.belenos"
+
+_SUPPORTED_BACKENDS = (_SIM_BELENOS, _QPU_BELENOS)
 
 _ALIASES = {
-    "sim:belenos": "quandela.sim.belenos",
-    "qpu:belenos": "quandela.qpu.belenos",
+    "sim:belenos": _SIM_BELENOS,
+    "qpu:belenos": _QPU_BELENOS,
 }
 
 _STATUS_MAP = {
@@ -107,14 +108,32 @@ def _import_qhub() -> dict:
         "client": HubQuantumClient,
         "credentials": DefaultCredentialsProvider,
         "input": {
-            "quandela.sim.belenos": CreateJobRequestInput_QuandelaSimBelenos,
-            "quandela.qpu.belenos": CreateJobRequestInput_QuandelaQpuBelenos,
+            _SIM_BELENOS: CreateJobRequestInput_QuandelaSimBelenos,
+            _QPU_BELENOS: CreateJobRequestInput_QuandelaQpuBelenos,
         },
         "params": {
-            "quandela.sim.belenos": CreateJobRequestInputParams_QuandelaSimBelenos,
-            "quandela.qpu.belenos": CreateJobRequestInputParams_QuandelaQpuBelenos,
+            _SIM_BELENOS: CreateJobRequestInputParams_QuandelaSimBelenos,
+            _QPU_BELENOS: CreateJobRequestInputParams_QuandelaQpuBelenos,
         },
     }
+
+
+def _build_httpx_client(proxies: dict | None):
+    """Build an httpx.Client routing through `proxies`, or None if none set.
+
+    Perceval proxies are requests-style ({scheme: url}); httpx wants per-scheme
+    transport mounts. httpx is imported lazily — it ships with qhub-api, not base
+    Perceval.
+    """
+    if not proxies:
+        return None
+    import httpx
+    mounts = {
+        f"{scheme}://": httpx.HTTPTransport(proxy=url)
+        for scheme, url in proxies.items()
+    }
+    # explicit timeout: injecting httpx_client bypasses qhub-api's 60s default
+    return httpx.Client(timeout=60, mounts=mounts)
 
 
 def _to_timestamp(value):
@@ -143,7 +162,9 @@ class KipuRPCHandler:
         resolved from the environment or the `qhubctl login` config file
     :param organization_id: optional Kipu organization id; when None your
         personal account is used
-    :param proxies: optional protocol->URL proxy mapping (stored for symmetry)
+    :param proxies: optional protocol->URL proxy mapping (requests-style, e.g.
+        ``{"https": "http://proxy:8080"}``); routed through the underlying httpx
+        client
     :param client: optional pre-built HubQuantumClient (used for testing)
     """
 
@@ -154,12 +175,6 @@ class KipuRPCHandler:
         self._token = token
         self._organization_id = organization_id
         self._proxies = proxies or {}
-        if self._proxies:
-            get_logger().warn(
-                "Kipu Quantum Hub provider does not support proxies; "
-                "the 'proxies' argument is ignored.",
-                channel.general,
-            )
         self._backend_id = _resolve_backend_id(platform_name)
         self._client = client if client is not None else self._build_client()
 
@@ -173,6 +188,9 @@ class KipuRPCHandler:
         }
         if self._url:
             kwargs["base_url"] = self._url
+        httpx_client = _build_httpx_client(self._proxies)
+        if httpx_client is not None:
+            kwargs["httpx_client"] = httpx_client
         return qhub["client"](**kwargs)
 
     @property

--- a/perceval/providers/kipu/kipu_rpc_handler.py
+++ b/perceval/providers/kipu/kipu_rpc_handler.py
@@ -29,6 +29,8 @@
 
 from datetime import datetime
 
+from perceval.utils.logging import get_logger, channel
+
 _MISSING_QHUB_MSG = (
     "The Kipu Quantum Hub provider requires the 'qhub-api' package. "
     "Install it with: pip install perceval[kipu]"
@@ -81,10 +83,11 @@ def _resolve_backend_id(platform_name: str) -> str:
 
 
 def _to_perceval_status(hub_status: str | None) -> str:
-    """Map a Hub JobStatus value to a Perceval status string."""
-    if hub_status is None:
-        return "unknown"
-    return _STATUS_MAP.get(str(hub_status), "unknown")
+    """Map a Hub JobStatus value to a Perceval status string.
+
+    A missing status (None) is not a map key, so it falls back to "unknown".
+    """
+    return _STATUS_MAP.get(hub_status, "unknown")
 
 
 def _import_qhub() -> dict:
@@ -117,11 +120,13 @@ def _import_qhub() -> dict:
 def _to_timestamp(value):
     """Convert an ISO-8601 datetime string to a POSIX timestamp (float).
 
-    Returns None for falsy input. Tolerates a trailing 'Z' (Python 3.10's
-    ``datetime.fromisoformat`` does not accept it).
+    Returns 0. for falsy input — Perceval's status parser coerces the timing
+    fields with float()/int(), so a numeric default avoids a spurious error log
+    on every poll (see ``_retrieve_from_response`` in remote_job.py). Tolerates a
+    trailing 'Z' (Python 3.10's ``datetime.fromisoformat`` does not accept it).
     """
     if not value:
-        return None
+        return 0.
     if isinstance(value, str) and value.endswith("Z"):
         # explicit offset: 3.10's fromisoformat rejects 'Z'; naive would be local
         value = value[:-1] + "+00:00"
@@ -149,6 +154,12 @@ class KipuRPCHandler:
         self._token = token
         self._organization_id = organization_id
         self._proxies = proxies or {}
+        if self._proxies:
+            get_logger().warn(
+                "Kipu Quantum Hub provider does not support proxies; "
+                "the 'proxies' argument is ignored.",
+                channel.general,
+            )
         self._backend_id = _resolve_backend_id(platform_name)
         self._client = client if client is not None else self._build_client()
 
@@ -197,7 +208,6 @@ class KipuRPCHandler:
             input=input_cls(value=inner),
             input_format="PERCEVAL",
             input_params=params_cls(
-                platform_name=payload.get("platform_name"),
                 pcvl_version=payload.get("pcvl_version"),
                 process_id=payload.get("process_id"),
             ),
@@ -219,7 +229,7 @@ class KipuRPCHandler:
         status_message = self._fetch_error_message(job_id) if status == "error" else None
         return {
             "creation_datetime": _to_timestamp(getattr(job, "created_at", None)),
-            "duration": getattr(job, "runtime", None),
+            "duration": getattr(job, "runtime", None) or 0.,
             "failure_code": None,
             "last_intermediate_results": None,
             "msg": "ok",

--- a/perceval/providers/kipu/kipu_rpc_handler.py
+++ b/perceval/providers/kipu/kipu_rpc_handler.py
@@ -1,0 +1,286 @@
+# MIT License
+#
+# Copyright (c) 2026 Kipu Quantum GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# As a special exception, the copyright holders of exqalibur library give you
+# permission to combine exqalibur with code included in the standard release of
+# Perceval under the MIT license (or modified versions of such code). You may
+# copy and distribute such a combined system following the terms of the MIT
+# license for both exqalibur and Perceval. This exception for the usage of
+# exqalibur is limited to the python bindings used by Perceval.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from datetime import datetime
+
+_MISSING_QHUB_MSG = (
+    "The Kipu Quantum Hub provider requires the 'qhub-api' package. "
+    "Install it with: pip install perceval[kipu]"
+)
+
+_SUPPORTED_BACKENDS = ("quandela.sim.belenos", "quandela.qpu.belenos")
+
+_ALIASES = {
+    "sim:belenos": "quandela.sim.belenos",
+    "qpu:belenos": "quandela.qpu.belenos",
+}
+
+_STATUS_MAP = {
+    "PENDING": "waiting",
+    "RUNNING": "running",
+    "COMPLETED": "completed",
+    "FAILED": "error",
+    "CANCELLING": "cancel_requested",
+    "CANCELLED": "canceled",
+    "ABORTED": "error",
+    "UNKNOWN": "unknown",
+}
+
+_BACKEND_TYPE_MAP = {
+    "SIMULATOR": "simulator",
+    "QPU": "qpu",
+    "ANNEALER": "qpu",
+    "UNKNOWN": "simulator",
+}
+
+
+def _resolve_backend_id(platform_name: str) -> str:
+    """Resolve a Perceval platform_name to a Kipu Hub backend id.
+
+    Accepts either a raw Hub backend id (e.g. "quandela.sim.belenos") or a
+    friendly alias (e.g. "sim:belenos").
+
+    :param platform_name: the platform name passed to the Kipu Session
+    :return: a supported Hub backend id
+    :raises ValueError: if the name resolves to an unsupported backend
+    """
+    backend_id = _ALIASES.get(platform_name, platform_name)
+    if backend_id not in _SUPPORTED_BACKENDS:
+        raise ValueError(
+            f"Unknown Kipu platform '{platform_name}'. "
+            f"Supported backends: {', '.join(_SUPPORTED_BACKENDS)} "
+            f"(aliases: {', '.join(_ALIASES)})."
+        )
+    return backend_id
+
+
+def _to_perceval_status(hub_status: str | None) -> str:
+    """Map a Hub JobStatus value to a Perceval status string."""
+    if hub_status is None:
+        return "unknown"
+    return _STATUS_MAP.get(str(hub_status), "unknown")
+
+
+def _import_qhub() -> dict:
+    """Lazily import qhub-api symbols. Raises a clear ImportError if absent."""
+    try:
+        from qhub.api.quantum import HubQuantumClient
+        from qhub.api.credentials import DefaultCredentialsProvider
+        from qhub.api.quantum.jobs import (
+            CreateJobRequestInput_QuandelaSimBelenos,
+            CreateJobRequestInput_QuandelaQpuBelenos,
+            CreateJobRequestInputParams_QuandelaSimBelenos,
+            CreateJobRequestInputParams_QuandelaQpuBelenos,
+        )
+    except ImportError as e:
+        raise ImportError(_MISSING_QHUB_MSG) from e
+    return {
+        "client": HubQuantumClient,
+        "credentials": DefaultCredentialsProvider,
+        "input": {
+            "quandela.sim.belenos": CreateJobRequestInput_QuandelaSimBelenos,
+            "quandela.qpu.belenos": CreateJobRequestInput_QuandelaQpuBelenos,
+        },
+        "params": {
+            "quandela.sim.belenos": CreateJobRequestInputParams_QuandelaSimBelenos,
+            "quandela.qpu.belenos": CreateJobRequestInputParams_QuandelaQpuBelenos,
+        },
+    }
+
+
+def _to_timestamp(value):
+    """Convert an ISO-8601 datetime string to a POSIX timestamp (float).
+
+    Returns None for falsy input. Tolerates a trailing 'Z' (Python 3.10's
+    ``datetime.fromisoformat`` does not accept it).
+    """
+    if not value:
+        return None
+    if isinstance(value, str) and value.endswith("Z"):
+        # explicit offset: 3.10's fromisoformat rejects 'Z'; naive would be local
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value).timestamp()
+
+
+class KipuRPCHandler:
+    """Duck-typed RPC handler for the Kipu Quantum Hub, backed by qhub-api.
+
+    :param platform_name: alias or Hub backend id (e.g. "quandela.sim.belenos")
+    :param url: optional Hub base URL; when None the qhub-api client uses its
+        own default Hub endpoint
+    :param token: optional Kipu Personal Access Token (PAT); when None it is
+        resolved from the environment or the `qhubctl login` config file
+    :param organization_id: optional Kipu organization id; when None your
+        personal account is used
+    :param proxies: optional protocol->URL proxy mapping (stored for symmetry)
+    :param client: optional pre-built HubQuantumClient (used for testing)
+    """
+
+    def __init__(self, platform_name, url=None, token=None, organization_id=None,
+                 proxies=None, client=None):
+        self._platform_name = platform_name
+        self._url = url
+        self._token = token
+        self._organization_id = organization_id
+        self._proxies = proxies or {}
+        self._backend_id = _resolve_backend_id(platform_name)
+        self._client = client if client is not None else self._build_client()
+
+    def _build_client(self):
+        qhub = _import_qhub()
+        # explicit token used as-is; None -> resolved from env / `qhubctl login`
+        api_key = qhub["credentials"](self._token).get_access_token()
+        kwargs = {
+            "api_key": api_key,
+            "organization_id": self._organization_id,
+        }
+        if self._url:
+            kwargs["base_url"] = self._url
+        return qhub["client"](**kwargs)
+
+    @property
+    def name(self) -> str:
+        return self._platform_name
+
+    @property
+    def url(self) -> str:
+        return self._url
+
+    @property
+    def proxies(self) -> dict:
+        return self._proxies
+
+    @property
+    def headers(self) -> dict:
+        # qhub-api manages auth via api_key; no raw headers to expose. Defined
+        # because RemoteJob._to_dict() reads it (job serialization / rerun).
+        return {}
+
+    def create_job(self, payload: dict) -> str:
+        """Submit a Perceval job payload to the Hub. Returns the Hub job id."""
+        qhub = _import_qhub()
+        inner = payload.get("payload") or {}
+        shots = inner.get("max_shots") or inner.get("max_samples") or 0
+
+        input_cls = qhub["input"][self._backend_id]
+        params_cls = qhub["params"][self._backend_id]
+
+        job = self._client.jobs.create_job(
+            backend_id=self._backend_id,
+            shots=shots,
+            input=input_cls(value=inner),
+            input_format="PERCEVAL",
+            input_params=params_cls(
+                platform_name=payload.get("platform_name"),
+                pcvl_version=payload.get("pcvl_version"),
+                process_id=payload.get("process_id"),
+            ),
+            sdk_provider="PERCEVAL",
+            name=payload.get("job_name"),
+        )
+        return job.id
+
+    def get_job_status(self, job_id: str) -> dict:
+        """Map the Hub job status to Perceval's status dict.
+
+        ``get_job_status`` returns the live status; ``get_job`` adds the timing
+        fields (creation/start/duration). Progress and failure code are not
+        exposed by the Hub; the error message for a failed job comes from the
+        result payload via ``_fetch_error_message`` (surfaced as status_message).
+        """
+        status = _to_perceval_status(getattr(self._client.jobs.get_job_status(job_id), "status", None))
+        job = self._client.jobs.get_job(job_id)
+        status_message = self._fetch_error_message(job_id) if status == "error" else None
+        return {
+            "creation_datetime": _to_timestamp(getattr(job, "created_at", None)),
+            "duration": getattr(job, "runtime", None),
+            "failure_code": None,
+            "last_intermediate_results": None,
+            "msg": "ok",
+            "progress": 1.0 if status == "completed" else 0.0,
+            "progress_message": None,
+            "start_time": _to_timestamp(getattr(job, "started_at", None)),
+            "status": status,
+            "status_message": status_message,
+        }
+
+    def _fetch_error_message(self, job_id: str):
+        """Best-effort error string for a failed job.
+
+        A failed Quandela job stores its error message (not a serialized result)
+        in the result payload's ``results`` field. Returns it as a string, or
+        None if it cannot be retrieved — status reporting must never break on the
+        error lookup.
+        """
+        try:
+            result = self._client.jobs.get_job_result(job_id)
+        except Exception:
+            return None
+        message = result.get("results") if isinstance(result, dict) else None
+        return message if isinstance(message, str) else None
+
+    def get_job_results(self, job_id: str) -> dict:
+        """Fetch Hub job results, normalized to Perceval's result envelope.
+
+        The Hub stores Quandela-native results already in Perceval's shape.
+        """
+        result = self._client.jobs.get_job_result(job_id)
+        return {
+            "duration": result.get("duration"),
+            "intermediate_results": result.get("intermediate_results", []),
+            "job_id": result.get("job_id", job_id),
+            "results": result.get("results"),
+            "results_type": result.get("results_type"),
+        }
+
+    def cancel_job(self, job_id: str) -> None:
+        """Cancel a running Hub job."""
+        self._client.jobs.cancel_job(job_id)
+
+    def rerun_job(self, job_id: str) -> str:
+        """Not supported by the Kipu Quantum Hub provider; always raises NotImplementedError."""
+        raise NotImplementedError(
+            "rerun_job is not implemented for the Kipu Quantum Hub provider"
+        )
+
+    def fetch_platform_details(self) -> dict:
+        """Return the Hub's platform details for this backend.
+
+        The Hub's backend-config endpoint relays Quandela Cloud's native
+        platform payload, which already matches the shape Perceval consumes
+        (a ``specs`` block with ``architecture``/``specific_circuit``,
+        ``available_commands``, ``constraints``, ``detector``, ... plus
+        top-level ``perfs`` and ``status``). We forward it as-is, only
+        ensuring ``type`` is set: the payload omits it, and Perceval would
+        otherwise default every platform to "simulator".
+        """
+        details = self._client.backends.get_backend_config(self._backend_id)
+        hub_type = "SIMULATOR" if ".sim." in self._backend_id else "QPU"
+        details.setdefault("type", _BACKEND_TYPE_MAP.get(hub_type, "simulator"))
+        return details

--- a/perceval/providers/kipu/kipu_session.py
+++ b/perceval/providers/kipu/kipu_session.py
@@ -1,0 +1,74 @@
+# MIT License
+#
+# Copyright (c) 2026 Kipu Quantum GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# As a special exception, the copyright holders of exqalibur library give you
+# permission to combine exqalibur with code included in the standard release of
+# Perceval under the MIT license (or modified versions of such code). You may
+# copy and distribute such a combined system following the terms of the MIT
+# license for both exqalibur and Perceval. This exception for the usage of
+# exqalibur is limited to the python bindings used by Perceval.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from perceval.runtime import ISession
+from perceval.runtime.remote_processor import RemoteProcessor
+from perceval.utils.logging import get_logger, channel
+
+from .kipu_rpc_handler import KipuRPCHandler
+
+
+class Session(ISession):
+    """
+    Kipu Quantum Hub session.
+
+    :param platform_name: Hub backend id or alias (e.g. "quandela.sim.belenos")
+    :param token: optional Kipu Personal Access Token (PAT); when omitted it is
+        resolved from the environment or the `qhubctl login` config file
+    :param organization_id: optional Kipu organization id; when omitted your
+        personal account is used
+    :param url: optional Hub base URL; when omitted the qhub-api client uses its
+        own default Hub endpoint
+    :param proxies: optional protocol->URL proxy mapping
+    """
+
+    def __init__(self, platform_name: str, token: str = None,
+                 organization_id: str = None, url: str = None,
+                 proxies: dict = None):
+        if not platform_name:
+            raise ValueError("platform_name cannot be None")
+        self._platform_name = platform_name
+        self._token = token
+        self._organization_id = organization_id
+        self._url = url
+        self._proxies = proxies or {}
+        get_logger().info(
+            f"Creating Kipu Session to {self._url or 'default Hub endpoint'}",
+            channel.general)
+
+    def build_remote_processor(self) -> RemoteProcessor:
+        """Build a RemoteProcessor wired to the Kipu Hub."""
+        handler = KipuRPCHandler(
+            platform_name=self._platform_name,
+            url=self._url,
+            token=self._token,
+            organization_id=self._organization_id,
+            proxies=self._proxies,
+        )
+        return RemoteProcessor(rpc_handler=handler)

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setuptools.setup(
                       'multipledispatch<2', 'drawsvg>=2.0', 'requests<3',
                       'networkx>=3.1,<4', 'latexcodec<4', 'platformdirs<5', 'tqdm',
                       ],
+    extras_require={"kipu": ["qhub-api>=2.0.0,<3"]},
     setup_requires=["scmver"],
     python_requires=">=3.10,<3.15",
     scmver=True

--- a/tests/providers/__init__.py
+++ b/tests/providers/__init__.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022 Quandela
+# Copyright (c) 2026 Kipu Quantum GmbH
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,30 +26,3 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""Provider related imports and classes"""
-
-from perceval.runtime import ISession
-
-from .quandela import Session as QuandelaSession
-from .scaleway import Session as ScalewaySession
-from .kipu import Session as KipuSession
-
-PROVIDER_LIST = {
-    "Quandela": QuandelaSession,
-    "Scaleway": ScalewaySession,
-    "Kipu": KipuSession,
-}
-
-
-class ProviderFactory:
-    @staticmethod
-    def get_provider(provider_name: str, **kwargs) -> ISession:
-        name = provider_name
-        if name in PROVIDER_LIST:
-            return PROVIDER_LIST[name](**kwargs)
-
-        raise KeyError(f'Cloud Provider "{name}" not found, available providers are: {ProviderFactory.list()}.')
-
-    @staticmethod
-    def list():
-        return list(PROVIDER_LIST.keys())

--- a/tests/providers/test_kipu_mappings.py
+++ b/tests/providers/test_kipu_mappings.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022 Quandela
+# Copyright (c) 2026 Kipu Quantum GmbH
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,30 +26,41 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""Provider related imports and classes"""
 
-from perceval.runtime import ISession
+import pytest
 
-from .quandela import Session as QuandelaSession
-from .scaleway import Session as ScalewaySession
-from .kipu import Session as KipuSession
-
-PROVIDER_LIST = {
-    "Quandela": QuandelaSession,
-    "Scaleway": ScalewaySession,
-    "Kipu": KipuSession,
-}
+from perceval.providers.kipu.kipu_rpc_handler import (
+    _resolve_backend_id,
+    _to_perceval_status,
+)
 
 
-class ProviderFactory:
-    @staticmethod
-    def get_provider(provider_name: str, **kwargs) -> ISession:
-        name = provider_name
-        if name in PROVIDER_LIST:
-            return PROVIDER_LIST[name](**kwargs)
+def test_resolve_backend_id_passthrough():
+    assert _resolve_backend_id("quandela.sim.belenos") == "quandela.sim.belenos"
+    assert _resolve_backend_id("quandela.qpu.belenos") == "quandela.qpu.belenos"
 
-        raise KeyError(f'Cloud Provider "{name}" not found, available providers are: {ProviderFactory.list()}.')
 
-    @staticmethod
-    def list():
-        return list(PROVIDER_LIST.keys())
+def test_resolve_backend_id_alias():
+    assert _resolve_backend_id("sim:belenos") == "quandela.sim.belenos"
+    assert _resolve_backend_id("qpu:belenos") == "quandela.qpu.belenos"
+
+
+def test_resolve_backend_id_unknown_raises():
+    with pytest.raises(ValueError, match="quandela.sim.belenos"):
+        _resolve_backend_id("nonsense")
+
+
+@pytest.mark.parametrize("hub_status,expected", [
+    ("PENDING", "waiting"),
+    ("RUNNING", "running"),
+    ("COMPLETED", "completed"),
+    ("FAILED", "error"),
+    ("CANCELLING", "cancel_requested"),
+    ("CANCELLED", "canceled"),
+    ("ABORTED", "error"),
+    ("UNKNOWN", "unknown"),
+    (None, "unknown"),
+    ("SOMETHING_NEW", "unknown"),
+])
+def test_to_perceval_status(hub_status, expected):
+    assert _to_perceval_status(hub_status) == expected

--- a/tests/providers/test_kipu_provider_registration.py
+++ b/tests/providers/test_kipu_provider_registration.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022 Quandela
+# Copyright (c) 2026 Kipu Quantum GmbH
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,30 +26,26 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""Provider related imports and classes"""
 
 from perceval.runtime import ISession
-
-from .quandela import Session as QuandelaSession
-from .scaleway import Session as ScalewaySession
-from .kipu import Session as KipuSession
-
-PROVIDER_LIST = {
-    "Quandela": QuandelaSession,
-    "Scaleway": ScalewaySession,
-    "Kipu": KipuSession,
-}
+from perceval.providers import ProviderFactory
 
 
-class ProviderFactory:
-    @staticmethod
-    def get_provider(provider_name: str, **kwargs) -> ISession:
-        name = provider_name
-        if name in PROVIDER_LIST:
-            return PROVIDER_LIST[name](**kwargs)
+def test_kipu_in_provider_list():
+    assert "Kipu" in ProviderFactory.list()
 
-        raise KeyError(f'Cloud Provider "{name}" not found, available providers are: {ProviderFactory.list()}.')
 
-    @staticmethod
-    def list():
-        return list(PROVIDER_LIST.keys())
+def test_get_kipu_provider():
+    session = ProviderFactory.get_provider(
+        "Kipu",
+        platform_name="quandela.sim.belenos",
+        token="t",
+        organization_id="org-1",
+    )
+    assert isinstance(session, ISession)
+
+
+def test_kipu_package_exports():
+    from perceval.providers.kipu import Session, KipuRPCHandler
+    assert Session is not None
+    assert KipuRPCHandler is not None

--- a/tests/providers/test_kipu_rpc_handler.py
+++ b/tests/providers/test_kipu_rpc_handler.py
@@ -1,0 +1,272 @@
+# MIT License
+#
+# Copyright (c) 2026 Kipu Quantum GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# As a special exception, the copyright holders of exqalibur library give you
+# permission to combine exqalibur with code included in the standard release of
+# Perceval under the MIT license (or modified versions of such code). You may
+# copy and distribute such a combined system following the terms of the MIT
+# license for both exqalibur and Perceval. This exception for the usage of
+# exqalibur is limited to the python bindings used by Perceval.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+import json
+
+import pytest
+pytest.importorskip("qhub")
+
+import perceval.providers.kipu.kipu_rpc_handler as kipu_mod
+from perceval.providers.kipu.kipu_rpc_handler import KipuRPCHandler
+
+
+def _make_handler(client=None, platform_name="quandela.sim.belenos", url=None):
+    return KipuRPCHandler(
+        platform_name=platform_name,
+        url=url,
+        token="test-token",
+        organization_id="test-org",
+        client=client or MagicMock(),
+    )
+
+
+def test_handler_properties():
+    handler = _make_handler()
+    assert handler.name == "quandela.sim.belenos"
+    assert handler.url is None
+    assert handler.proxies == {}
+    assert handler.headers == {}
+
+
+def test_handler_url_passthrough():
+    handler = _make_handler(url="https://hub.example.test/quantum")
+    assert handler.url == "https://hub.example.test/quantum"
+
+
+def test_handler_resolves_backend_id():
+    handler = _make_handler(platform_name="sim:belenos")
+    assert handler._backend_id == "quandela.sim.belenos"
+
+
+def test_missing_qhub_raises_clear_error(monkeypatch):
+    monkeypatch.setitem(sys.modules, "qhub.api.quantum", None)
+    with pytest.raises(ImportError, match=r"pip install perceval\[kipu\]"):
+        kipu_mod._import_qhub()
+
+
+def test_create_job_builds_typed_request_and_returns_id():
+    client = MagicMock()
+    client.jobs.create_job.return_value = SimpleNamespace(id="job-123")
+    handler = _make_handler(client=client)
+
+    payload = {
+        "pcvl_version": "1.0",
+        "process_id": "proc-1",
+        "platform_name": "quandela.sim.belenos",
+        "job_name": "toy",
+        "payload": {"command": "samples", "max_shots": 1000},
+    }
+    job_id = handler.create_job(payload)
+
+    assert job_id == "job-123"
+    kwargs = client.jobs.create_job.call_args.kwargs
+    assert kwargs["backend_id"] == "quandela.sim.belenos"
+    assert kwargs["shots"] == 1000
+    assert kwargs["input_format"] == "PERCEVAL"
+    assert kwargs["sdk_provider"] == "PERCEVAL"
+    assert kwargs["name"] == "toy"
+    assert kwargs["input"].value == payload["payload"]
+    assert kwargs["input_params"].platform_name == "quandela.sim.belenos"
+    assert kwargs["input_params"].pcvl_version == "1.0"
+    assert kwargs["input_params"].process_id == "proc-1"
+
+
+def test_create_job_falls_back_to_max_samples_for_shots():
+    client = MagicMock()
+    client.jobs.create_job.return_value = SimpleNamespace(id="job-9")
+    handler = _make_handler(client=client)
+    handler.create_job({"payload": {"command": "samples", "max_samples": 500}})
+    assert client.jobs.create_job.call_args.kwargs["shots"] == 500
+
+
+def test_get_job_status_maps_completed_with_timing():
+    client = MagicMock()
+    client.jobs.get_job_status.return_value = SimpleNamespace(status="COMPLETED")
+    client.jobs.get_job.return_value = SimpleNamespace(
+        created_at="2024-03-01T15:33:43Z",
+        started_at="2024-03-01T15:33:45Z",
+        runtime=12,
+    )
+    handler = _make_handler(client=client)
+
+    status = handler.get_job_status("job-1")
+    client.jobs.get_job_status.assert_called_once_with("job-1")
+    client.jobs.get_job.assert_called_once_with("job-1")
+    assert status["status"] == "completed"
+    assert status["progress"] == 1.0
+    assert status["msg"] == "ok"
+    assert status["duration"] == 12
+    assert isinstance(status["creation_datetime"], float)
+    assert isinstance(status["start_time"], float)
+    assert status["start_time"] - status["creation_datetime"] == pytest.approx(2.0)
+    for key in ("creation_datetime", "duration", "start_time",
+                "progress_message", "status_message", "failure_code"):
+        assert key in status
+    assert status["status_message"] is None
+    client.jobs.get_job_result.assert_not_called()
+
+
+def test_get_job_status_maps_running():
+    client = MagicMock()
+    client.jobs.get_job_status.return_value = SimpleNamespace(status="RUNNING")
+    client.jobs.get_job.return_value = SimpleNamespace(
+        created_at=None, started_at=None, runtime=None)
+    handler = _make_handler(client=client)
+    status = handler.get_job_status("job-2")
+    assert status["status"] == "running"
+    assert status["progress"] == 0.0
+    assert status["start_time"] is None
+    assert status["duration"] is None
+    client.jobs.get_job_result.assert_not_called()
+
+
+def test_get_job_status_failed_surfaces_error_message():
+    client = MagicMock()
+    client.jobs.get_job_status.return_value = SimpleNamespace(status="FAILED")
+    client.jobs.get_job.return_value = SimpleNamespace(
+        created_at=None, started_at=None, runtime=None)
+    client.jobs.get_job_result.return_value = {
+        "results": "Error -3 while decompressing data: incorrect data check"}
+    handler = _make_handler(client=client)
+
+    status = handler.get_job_status("job-err")
+    assert status["status"] == "error"
+    client.jobs.get_job_result.assert_called_once_with("job-err")
+    assert status["status_message"] == (
+        "Error -3 while decompressing data: incorrect data check")
+
+
+def test_get_job_status_failed_error_lookup_is_best_effort():
+    client = MagicMock()
+    client.jobs.get_job_status.return_value = SimpleNamespace(status="FAILED")
+    client.jobs.get_job.return_value = SimpleNamespace(
+        created_at=None, started_at=None, runtime=None)
+    client.jobs.get_job_result.side_effect = RuntimeError("boom")
+    handler = _make_handler(client=client)
+    status = handler.get_job_status("job-err")
+    assert status["status"] == "error"
+    assert status["status_message"] is None
+
+
+def test_get_job_results_passthrough_envelope():
+    inner = json.dumps({"results": ":PCVL:BasicState:|0,1>", "logical_perf": 1})
+    client = MagicMock()
+    client.jobs.get_job_result.return_value = {
+        "duration": 2,
+        "intermediate_results": [],
+        "job_id": "job-7",
+        "results": inner,
+        "results_type": None,
+        "shots": 1000,
+    }
+    handler = _make_handler(client=client)
+
+    out = handler.get_job_results("job-7")
+    client.jobs.get_job_result.assert_called_once_with("job-7")
+    assert set(out) == {"duration", "intermediate_results", "job_id",
+                        "results", "results_type"}
+    assert out["results"] == inner
+    assert out["job_id"] == "job-7"
+    assert out["duration"] == 2
+
+
+def test_get_job_results_defaults_job_id_when_absent():
+    client = MagicMock()
+    client.jobs.get_job_result.return_value = {"results": None}
+    handler = _make_handler(client=client)
+    out = handler.get_job_results("fallback-id")
+    assert out["job_id"] == "fallback-id"
+    assert out["intermediate_results"] == []
+
+
+def test_cancel_job_calls_client():
+    client = MagicMock()
+    handler = _make_handler(client=client)
+    handler.cancel_job("job-x")
+    client.jobs.cancel_job.assert_called_once_with("job-x")
+
+
+def test_rerun_job_not_implemented():
+    handler = _make_handler()
+    with pytest.raises(NotImplementedError):
+        handler.rerun_job("job-x")
+
+
+# Trimmed sample of the Hub backend-config payload (Quandela-native).
+_CONFIG_PAYLOAD = {
+    "name": "sim:belenos",
+    "status": "online",
+    "perfs": {},
+    "specs": {
+        "available_commands": ["sample_count", "samples"],
+        "connected_input_modes": [1, 3, 5, 7],
+        "constraints": {
+            "max_mode_count": 20,
+            "min_mode_count": 1,
+            "max_photon_count": 10,
+            "min_photon_count": 1,
+        },
+        "detector": "threshold",
+        "specific_circuit": ":PCVL:zip:fake",
+    },
+}
+
+
+def test_fetch_platform_details_forwards_config_and_injects_type():
+    client = MagicMock()
+    client.backends.get_backend_config.return_value = dict(_CONFIG_PAYLOAD)
+    handler = _make_handler(client=client)
+
+    details = handler.fetch_platform_details()
+    client.backends.get_backend_config.assert_called_once_with(
+        "quandela.sim.belenos")
+    assert details["specs"] == _CONFIG_PAYLOAD["specs"]
+    assert details["perfs"] == {}
+    assert details["status"] == "online"
+    assert details["type"] == "simulator"
+
+
+def test_fetch_platform_details_injects_qpu_type():
+    client = MagicMock()
+    client.backends.get_backend_config.return_value = dict(_CONFIG_PAYLOAD)
+    handler = _make_handler(client=client, platform_name="quandela.qpu.belenos")
+    details = handler.fetch_platform_details()
+    assert details["type"] == "qpu"
+
+
+def test_fetch_platform_details_does_not_override_existing_type():
+    payload = dict(_CONFIG_PAYLOAD, type="qpu")
+    client = MagicMock()
+    client.backends.get_backend_config.return_value = payload
+    handler = _make_handler(client=client)  # sim backend ...
+    details = handler.fetch_platform_details()
+    assert details["type"] == "qpu"  # ... but payload's own type wins

--- a/tests/providers/test_kipu_rpc_handler.py
+++ b/tests/providers/test_kipu_rpc_handler.py
@@ -33,7 +33,8 @@ from unittest.mock import MagicMock
 import json
 
 import pytest
-pytest.importorskip("qhub")
+# qhub is a namespace package; guard on the concrete submodule so the suite skips when [kipu] is absent.
+pytest.importorskip("qhub.api.quantum")
 
 import perceval.providers.kipu.kipu_rpc_handler as kipu_mod
 from perceval.providers.kipu.kipu_rpc_handler import KipuRPCHandler

--- a/tests/providers/test_kipu_rpc_handler.py
+++ b/tests/providers/test_kipu_rpc_handler.py
@@ -58,6 +58,30 @@ def test_handler_properties():
     assert handler.headers == {}
 
 
+def test_handler_warns_on_unsupported_proxies(monkeypatch):
+    warnings = []
+    logger = MagicMock()
+    logger.warn.side_effect = lambda msg, *a, **k: warnings.append(msg)
+    monkeypatch.setattr(kipu_mod, "get_logger", lambda: logger)
+
+    handler = KipuRPCHandler(
+        platform_name="quandela.sim.belenos",
+        token="test-token",
+        proxies={"https": "http://proxy:8080"},
+        client=MagicMock(),
+    )
+    assert handler.proxies == {"https": "http://proxy:8080"}
+    assert len(warnings) == 1
+    assert "proxies" in warnings[0]
+
+
+def test_handler_no_proxy_warning_when_absent(monkeypatch):
+    logger = MagicMock()
+    monkeypatch.setattr(kipu_mod, "get_logger", lambda: logger)
+    _make_handler()
+    logger.warn.assert_not_called()
+
+
 def test_handler_url_passthrough():
     handler = _make_handler(url="https://hub.example.test/quantum")
     assert handler.url == "https://hub.example.test/quantum"
@@ -96,7 +120,6 @@ def test_create_job_builds_typed_request_and_returns_id():
     assert kwargs["sdk_provider"] == "PERCEVAL"
     assert kwargs["name"] == "toy"
     assert kwargs["input"].value == payload["payload"]
-    assert kwargs["input_params"].platform_name == "quandela.sim.belenos"
     assert kwargs["input_params"].pcvl_version == "1.0"
     assert kwargs["input_params"].process_id == "proc-1"
 
@@ -123,7 +146,7 @@ def test_get_job_status_maps_completed_with_timing():
     client.jobs.get_job_status.assert_called_once_with("job-1")
     client.jobs.get_job.assert_called_once_with("job-1")
     assert status["status"] == "completed"
-    assert status["progress"] == 1.0
+    assert status["progress"] == pytest.approx(1.0)
     assert status["msg"] == "ok"
     assert status["duration"] == 12
     assert isinstance(status["creation_datetime"], float)
@@ -144,9 +167,11 @@ def test_get_job_status_maps_running():
     handler = _make_handler(client=client)
     status = handler.get_job_status("job-2")
     assert status["status"] == "running"
-    assert status["progress"] == 0.0
-    assert status["start_time"] is None
-    assert status["duration"] is None
+    assert status["progress"] == pytest.approx(0.0)
+    # missing timing fields default to a number, not None: Perceval coerces
+    # them with float()/int(), so None would spam an error log on every poll
+    assert status["start_time"] == pytest.approx(0.0)
+    assert status["duration"] == pytest.approx(0.0)
     client.jobs.get_job_result.assert_not_called()
 
 

--- a/tests/providers/test_kipu_rpc_handler.py
+++ b/tests/providers/test_kipu_rpc_handler.py
@@ -27,7 +27,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import socket
 import sys
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 import json
@@ -58,28 +60,62 @@ def test_handler_properties():
     assert handler.headers == {}
 
 
-def test_handler_warns_on_unsupported_proxies(monkeypatch):
-    warnings = []
-    logger = MagicMock()
-    logger.warn.side_effect = lambda msg, *a, **k: warnings.append(msg)
-    monkeypatch.setattr(kipu_mod, "get_logger", lambda: logger)
-
-    handler = KipuRPCHandler(
-        platform_name="quandela.sim.belenos",
-        token="test-token",
-        proxies={"https": "http://proxy:8080"},
-        client=MagicMock(),
-    )
-    assert handler.proxies == {"https": "http://proxy:8080"}
-    assert len(warnings) == 1
-    assert "proxies" in warnings[0]
+def test_build_httpx_client_none_without_proxies():
+    assert kipu_mod._build_httpx_client({}) is None
+    assert kipu_mod._build_httpx_client(None) is None
 
 
-def test_handler_no_proxy_warning_when_absent(monkeypatch):
-    logger = MagicMock()
-    monkeypatch.setattr(kipu_mod, "get_logger", lambda: logger)
-    _make_handler()
-    logger.warn.assert_not_called()
+def test_build_httpx_client_routes_traffic_through_proxy():
+    # A one-shot local socket standing in for a proxy: an HTTP/1.1 request routed
+    # through a proxy uses absolute-form ("GET http://host/path"), whereas a direct
+    # request uses origin-form ("GET /path"). Seeing absolute-form proves routing.
+    captured = {}
+
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+
+    def serve():
+        conn, _ = server.accept()
+        with conn:
+            data = b""
+            while b"\r\n\r\n" not in data:
+                chunk = conn.recv(4096)
+                if not chunk:
+                    break
+                data += chunk
+            captured["request_line"] = data.split(b"\r\n", 1)[0].decode()
+            conn.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+
+    client = kipu_mod._build_httpx_client({"http": f"http://127.0.0.1:{port}"})
+    try:
+        resp = client.get("http://proxy-target.test/ping")
+    finally:
+        client.close()
+        thread.join(timeout=5)
+        server.close()
+
+    assert resp.status_code == 200
+    assert captured["request_line"].startswith("GET http://proxy-target.test/ping")
+
+
+@pytest.mark.parametrize("proxies, injected", [
+    ({"https": "http://proxy:8080"}, True),
+    (None, False),
+])
+def test_build_client_injects_httpx_client_only_when_proxied(monkeypatch, proxies, injected):
+    captured = {}
+    monkeypatch.setattr(kipu_mod, "_import_qhub", lambda: {
+        "client": lambda **kwargs: captured.update(kwargs) or MagicMock(),
+        "credentials": lambda token: SimpleNamespace(get_access_token=lambda: "key"),
+    })
+    KipuRPCHandler(platform_name="quandela.sim.belenos", token="test-token", proxies=proxies)
+    assert ("httpx_client" in captured) is injected
 
 
 def test_handler_url_passthrough():

--- a/tests/providers/test_kipu_session.py
+++ b/tests/providers/test_kipu_session.py
@@ -28,7 +28,8 @@
 # SOFTWARE.
 
 import pytest
-pytest.importorskip("qhub")
+# qhub is a namespace package; guard on the concrete submodule so the suite skips when [kipu] is absent.
+pytest.importorskip("qhub.api.quantum")
 from unittest.mock import patch
 
 from perceval.providers.kipu.kipu_session import Session

--- a/tests/providers/test_kipu_session.py
+++ b/tests/providers/test_kipu_session.py
@@ -1,0 +1,82 @@
+# MIT License
+#
+# Copyright (c) 2026 Kipu Quantum GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# As a special exception, the copyright holders of exqalibur library give you
+# permission to combine exqalibur with code included in the standard release of
+# Perceval under the MIT license (or modified versions of such code). You may
+# copy and distribute such a combined system following the terms of the MIT
+# license for both exqalibur and Perceval. This exception for the usage of
+# exqalibur is limited to the python bindings used by Perceval.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+pytest.importorskip("qhub")
+from unittest.mock import patch
+
+from perceval.providers.kipu.kipu_session import Session
+from perceval.runtime.remote_processor import RemoteProcessor
+
+_PLATFORM_DETAILS = {
+    "name": "quandela.sim.belenos",
+    "status": "available",
+    "type": "simulator",
+    "specs": {
+        "available_commands": ["probs"],
+        "constraints": {
+            "max_mode_count": 20,
+            "max_photon_count": 6,
+            "min_mode_count": 1,
+            "min_photon_count": 1,
+        },
+    },
+    "perfs": {},
+}
+
+
+def test_session_token_is_optional():
+    session = Session(platform_name="quandela.sim.belenos", token=None)
+    assert session is not None
+
+
+def test_session_requires_platform_name():
+    with pytest.raises(ValueError):
+        Session(platform_name=None, token="t")
+
+
+@patch("perceval.providers.kipu.kipu_rpc_handler.KipuRPCHandler.fetch_platform_details",
+       return_value=_PLATFORM_DETAILS)
+def test_session_organization_id_is_optional(mock_fetch):
+    session = Session(platform_name="quandela.sim.belenos", token="t")
+    processor = session.build_remote_processor()
+    assert isinstance(processor, RemoteProcessor)
+    assert processor.name == "quandela.sim.belenos"
+    mock_fetch.assert_called_once()
+
+
+@patch("perceval.providers.kipu.kipu_rpc_handler.KipuRPCHandler.fetch_platform_details",
+       return_value=_PLATFORM_DETAILS)
+def test_session_builds_remote_processor_with_org(mock_fetch):
+    session = Session(platform_name="quandela.sim.belenos", token="t",
+                      organization_id="org-1")
+    processor = session.build_remote_processor()
+    assert isinstance(processor, RemoteProcessor)
+    assert processor.name == "quandela.sim.belenos"
+    mock_fetch.assert_called_once()

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,4 +6,3 @@ responses
 pytest-responses
 flaky
 matplotlib ~= 3.10.0  # TODO: remove this and repair test when dropping python 3.10
-qhub-api>=2.0.0,<3

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,3 +6,4 @@ responses
 pytest-responses
 flaky
 matplotlib ~= 3.10.0  # TODO: remove this and repair test when dropping python 3.10
+qhub-api>=2.0.0,<3


### PR DESCRIPTION
Adds an optional cloud provider, `perceval.providers.kipu`, that submits jobs through the
[Kipu Quantum Hub](https://dashboard.hub.kipu-quantum.com/). The Hub routes quantum jobs to multiple hardware providers. Through it, Perceval can run the Quandela photonic backends exposed
on the Hub — `quandela.sim.belenos` and `quandela.qpu.belenos`, which are the Hub's ids for
Quandela's native `sim:belenos` and `qpu:belenos` platforms.

**Adds**
- `perceval/providers/kipu/` — `Session` + `KipuRPCHandler`, same pattern as the `quandela`/`scaleway` providers.
- Auth via Kipu Personal Access Token (or `qhubctl`), optional `organization_id`.
- Docs in `docs/source/reference/providers.rst`; offline unit tests in `tests/providers/`.

**Optional dependency** — `qhub-api`, via the `[kipu]` extra (`pip install perceval[kipu]`), imported
lazily. Base Perceval is unchanged without it; tests skip the Hub-backed cases cleanly when absent.

**Usage**
```python
import perceval as pcvl
import perceval.providers.kipu as kipu

session = kipu.Session(platform_name="quandela.sim.belenos", token="<your-PAT>")
processor = session.build_remote_processor()
# build a circuit, then sample as with any RemoteProcessor
```

Purely additive — no change to existing providers. `flake8` + `pytest tests/providers` pass with and without the extra.
